### PR TITLE
feat: add gzip support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 ## 0.2.0 [unreleased]
 
+### Features
+1. [#32](https://github.com/InfluxCommunity/influxdb3-csharp/pull/33): Add GZIP support
+
 ## 0.1.0 [2023-06-09]
 
 - initial release of new client version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.2.0 [unreleased]
 
 ### Features
+
 1. [#32](https://github.com/InfluxCommunity/influxdb3-csharp/pull/33): Add GZIP support
 
 ## 0.1.0 [2023-06-09]

--- a/Client.Test.Integration/QueryWriteTest.cs
+++ b/Client.Test.Integration/QueryWriteTest.cs
@@ -8,6 +8,8 @@ using InfluxDB3.Client.Query;
 using InfluxDB3.Client.Write;
 using NUnit.Framework;
 
+using WriteOptions = InfluxDB3.Client.Config.WriteOptions;
+
 namespace InfluxDB3.Client.Test.Integration;
 
 public class QueryWriteTest
@@ -105,5 +107,23 @@ public class QueryWriteTest
         });
 
         await client.WritePointAsync(PointData.Measurement("cpu").AddTag("tag", "c"));
+    }
+
+
+    [Test]
+    public async Task WriteDataGzipped()
+    {
+        using var client = new InfluxDBClient(new InfluxDBClientConfigs
+        {
+            HostUrl = _hostUrl,
+            Database = _database,
+            AuthToken = _authToken,
+            WriteOptions = new WriteOptions
+            {
+                GzipThreshold = 1
+            }
+        });
+
+        await client.WritePointAsync(PointData.Measurement("cpu").AddTag("tag", "c").AddField("user", 14.34));
     }
 }

--- a/Client.Test/InfluxDBClientWriteTest.cs
+++ b/Client.Test/InfluxDBClientWriteTest.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Threading.Tasks;
 using InfluxDB3.Client.Config;
 using InfluxDB3.Client.Write;
+using WireMock.Matchers;
 using WireMock.RequestBuilders;
 using WireMock.ResponseBuilders;
 
@@ -74,7 +75,7 @@ public class InfluxDBClientWriteTest : MockServerTest
         Assert.That(requests[0].RequestMessage.BodyData?.BodyAsString, Is.EqualTo("mem,tag=a field=1"));
     }
 
-   [Test]
+    [Test]
     public async Task BodyNonDefaultGzipped()
     {
         MockServer
@@ -93,10 +94,22 @@ public class InfluxDBClientWriteTest : MockServerTest
         });
 
         await _client.WriteRecordAsync("mem,tag=a field=1");
-        foreach (var entry in MockServer.LogEntries.ToList())
-        {
-            Console.WriteLine(entry);
-        }
+        var requests = MockServer.LogEntries.ToList();
+        Assert.That(requests[0].RequestMessage.BodyData?.BodyAsString, Is.EqualTo("mem,tag=a field=1"));
+    }
+
+    [Test]
+    public async Task BodyDefaultNotGzipped()
+    {
+        MockServer
+            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("Content-Encoding", ".*", MatchBehaviour.RejectOnMatch).UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+         _client = new InfluxDBClient(MockServerUrl, null, "org", "database");
+
+        await _client.WriteRecordAsync("mem,tag=a field=1");
+        var requests = MockServer.LogEntries.ToList();
+        Assert.That(requests[0].RequestMessage.BodyData?.BodyAsString, Is.EqualTo("mem,tag=a field=1"));
     }
 
     [Test]

--- a/Client.Test/InfluxDBClientWriteTest.cs
+++ b/Client.Test/InfluxDBClientWriteTest.cs
@@ -82,7 +82,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             .Given(Request.Create().WithPath("/api/v2/write").WithHeader("Content-Encoding", "gzip").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
-         _client = new InfluxDBClient(new InfluxDBClientConfigs
+        _client = new InfluxDBClient(new InfluxDBClientConfigs
         {
             HostUrl = MockServerUrl,
             Organization = "org",
@@ -105,7 +105,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             .Given(Request.Create().WithPath("/api/v2/write").WithHeader("Content-Encoding", ".*", MatchBehaviour.RejectOnMatch).UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
-         _client = new InfluxDBClient(MockServerUrl, null, "org", "database");
+        _client = new InfluxDBClient(MockServerUrl, null, "org", "database");
 
         await _client.WriteRecordAsync("mem,tag=a field=1");
         var requests = MockServer.LogEntries.ToList();

--- a/Client/Config/InfluxDBClientConfigs.cs
+++ b/Client/Config/InfluxDBClientConfigs.cs
@@ -39,11 +39,6 @@ public class InfluxDBClientConfigs
     public string? Database { get; set; }
 
     /// <summary>
-    /// The default precision to use for the timestamp of points if no precision is specified in the write API call.
-    /// </summary>
-    public WritePrecision? WritePrecision { get; set; }
-
-    /// <summary>
     /// Timeout to wait before the HTTP request times out. Default to '10 seconds'.
     /// </summary>
     public TimeSpan Timeout { get; set; } = TimeSpan.FromSeconds(10);
@@ -58,11 +53,21 @@ public class InfluxDBClientConfigs
     /// </summary>
     public bool DisableServerCertificateValidation { get; set; }
 
+    /// <summary>
+    /// Write options.
+    /// </summary>
+    public WriteOptions? WriteOptions { get; set; }
+
     internal void Validate()
     {
         if (string.IsNullOrEmpty(HostUrl))
         {
             throw new ArgumentException("The hostname or IP address of the InfluxDB server has to be defined.");
         }
+    }
+
+    internal WritePrecision WritePrecision
+    {
+        get => WriteOptions != null ? WriteOptions.Precision ?? WritePrecision.Ns : WritePrecision.Ns;
     }
 }

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -1,0 +1,22 @@
+using InfluxDB3.Client.Write;
+
+namespace InfluxDB3.Client.Config;
+
+public class WriteOptions
+{
+    /// <summary>
+    /// The default precision to use for the timestamp of points if no precision is specified in the write API call.
+    /// </summary>
+    public WritePrecision? Precision { get; set; }
+
+    /// <summary>
+    /// The threshold in bytes for gzipping the body.
+    /// </summary>
+    public int GzipThreshold { get; set; }
+
+    internal static readonly WriteOptions DefaultOptions = new()
+    {
+        Precision = WritePrecision.Ns,
+        GzipThreshold = 1000
+    };    
+}

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -18,5 +18,5 @@ public class WriteOptions
     {
         Precision = WritePrecision.Ns,
         GzipThreshold = 1000
-    };    
+    };
 }

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -2,6 +2,27 @@ using InfluxDB3.Client.Write;
 
 namespace InfluxDB3.Client.Config;
 
+/// <summary>
+/// The WriteOptions class holds the configuration for writing data to InfluxDB.
+///
+/// You can configure following options:
+/// - Precision: The default precision to use for the timestamp of points if no precision is specified in the write API call.
+/// - GzipThreshold: The threshold in bytes for gzipping the body. The default value is 1000.
+///
+/// If you want create client with custom options, you can use the following code:
+/// <code>
+/// using var client = new InfluxDBClient(new InfluxDBClientConfigs{
+///     HostUrl = "https://us-east-1-1.aws.cloud2.influxdata.com",
+///     Organization = "my-org",
+///     Database = "my-database",
+///     WriteOptions = new WriteOptions
+///    {
+///        Precision = WritePrecision.S,
+///         GzipThreshold = 4096
+///    }
+/// }); 
+/// </code>
+/// </summary>
 public class WriteOptions
 {
     /// <summary>

--- a/Client/Internal/GzipHandler.cs
+++ b/Client/Internal/GzipHandler.cs
@@ -1,0 +1,41 @@
+using System;
+using System.IO;
+using System.IO.Compression;
+using System.Linq;
+using System.Net.Http;
+using System.Text;
+
+namespace InfluxDB3.Client.Internal;
+
+internal class GzipHandler
+{
+    private readonly int _threshold;
+
+    public GzipHandler(int threshold)
+    {
+        _threshold = threshold;
+    }
+
+    public HttpContent? Process(string body)
+    {
+        if (_threshold > 0 && body.Length < _threshold)
+        {
+            return null;
+        }
+
+        using (var msi = new MemoryStream(Encoding.UTF8.GetBytes(body)))
+        using (var mso = new MemoryStream())
+        {
+            using (var gs = new GZipStream(mso, CompressionMode.Compress))
+            {
+                msi.CopyTo(gs);
+                gs.Flush();
+            }
+
+            var content = new ByteArrayContent(mso.ToArray());
+            content.Headers.Add("Content-Type", "text/plain; charset=utf-8");
+            content.Headers.Add("Content-Encoding", "gzip");
+            return content;
+        }
+    }
+}


### PR DESCRIPTION
## Proposed Changes

* adds request body gzip compression controlled via payload content length (similarly to already existing support in Go and Javascript clients):
  * threshold and _timestamp writing precision_ are now options in `WriteOptions` struct nested in `InfluxDBClientConfigs` - this is breaking API change!
* enables automatic response decompression

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
