### PR TITLE
fix: respect DNS changes in HttpClient

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 ## 0.3.0 [unreleased]
 
+1. [#43](https://github.com/InfluxCommunity/influxdb3-csharp/issues/43): Respect DNS changes in HttpClient
+
 ## 0.2.0 [2023-08-11]
 
 ### Features

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -309,7 +309,9 @@ namespace InfluxDB3.Client
 
         internal static HttpClient CreateAndConfigureHttpClient(ClientConfig config)
         {
-            var handler = new HttpClientHandler();
+            var handler = new HttpClientHandler {
+                PooledConnectionLifetime = TimeSpan.FromMinutes(5)
+            };
             if (handler.SupportsRedirectConfiguration)
             {
                 handler.AllowAutoRedirect = config.AllowHttpRedirects;


### PR DESCRIPTION
Closes #43 

## Proposed Changes

As the InfluxDBClient is recommended to be used as a singleton, set PooledConnectionLifetime on the HttpClient so that any DNS changes are respected. This is required as HttpClient resolves DNS entries at connection creation time only.

I've set it 5 minutes as this was the TTL I saw on eu-central-1-1.aws.cloud2.influxdata.com

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
