### PR TITLE
chore(ci): use net8.0 as a default target framework in Tests and Examples

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,8 +4,7 @@ commands:
     parameters:
       project:
         type: string
-      net-version:
-        type: string
+        default: "Client.Test"
     steps:
       - checkout
       - run:
@@ -20,7 +19,7 @@ commands:
             mkdir test-results
       - run:
           name: Run tests
-          command: dotnet test "<< parameters.project >>/bin/Debug/net<< parameters.net-version >>/InfluxDB3.<< parameters.project >>.dll" --collect "Xplat Code Coverage" --logger "junit;LogFilePath=../test-results/test-result.xml"
+          command: dotnet test << parameters.project >> --collect "Xplat Code Coverage" --logger "junit;LogFilePath=../test-results/test-result.xml"
       - run:
           name: Coverage Report
           command: |
@@ -51,34 +50,18 @@ commands:
 jobs:
   tests-unit:
     working_directory: ~/repo
-    parameters:
-      net-version:
-        type: string
-        default: &default-dotnet-version "8.0"
-      net-image:
-        type: string
-        default: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:8.0"
     docker:
-      - image: << parameters.net-image >>
+      - image: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:7.0"
     steps:
       - client-test:
           project: "Client.Test"
-          net-version: << parameters.net-version >>
   tests-integration:
     working_directory: ~/repo
-    parameters:
-      net-version:
-        type: string
-        default: *default-dotnet-version
-      net-image:
-        type: string
-        default: *default-dotnet-image
     docker:
-      - image: << parameters.net-image >>
+      - image: *default-dotnet-image
     steps:
       - client-test:
           project: "Client.Test.Integration"
-          net-version: << parameters.net-version >>
           
   check-compilation-warnings:
     docker:
@@ -114,15 +97,13 @@ workflows:
   build:
     jobs:
       - check-compilation-warnings
-      - tests-unit:
-          name: "Unit Tests .NET 8.0"
+      - tests-unit
       - tests-integration:
-          name: "Integration Tests .NET 8.0"
           requires:
-            - "Unit Tests .NET 8.0"
+            - "tests-unit"
       - deploy-preview:
           requires:
-            - "Integration Tests .NET 8.0"
+            - tests-integration
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,18 +50,32 @@ commands:
 jobs:
   tests-unit:
     working_directory: ~/repo
+    parameters:
+      net-version:
+        type: string
+        default: &default-dotnet-version "8.0"
+      net-image:
+        type: string
+        default: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:8.0"
     docker:
-      - image: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:8.0"
+      - image: << parameters.net-image >>
     steps:
       - client-test:
-          project: "Client.Test"
+          project: "Client.Test/bin/Debug/net<< parameters.net-version >>/InfluxDB3.Client.Test.dll"
   tests-integration:
     working_directory: ~/repo
+    parameters:
+      net-version:
+        type: string
+        default: *default-dotnet-version
+      net-image:
+        type: string
+        default: *default-dotnet-image
     docker:
-      - image: *default-dotnet-image
+      - image: << parameters.net-image >>
     steps:
       - client-test:
-          project: "Client.Test.Integration"
+          project: "Client.Test.Integration/bin/Debug/net<< parameters.net-version >>/InfluxDB3.Client.Test.Integration.dll"
           
   check-compilation-warnings:
     docker:
@@ -97,13 +111,15 @@ workflows:
   build:
     jobs:
       - check-compilation-warnings
-      - tests-unit
+      - tests-unit:
+          name: "Unit Tests .NET 8.0"
       - tests-integration:
+          name: "Integration Tests .NET 8.0"
           requires:
-            - "tests-unit"
+            - "Unit Tests .NET 8.0"
       - deploy-preview:
           requires:
-            - tests-integration
+            - "Integration Tests .NET 8.0"
           filters:
             branches:
               only: main

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -51,7 +51,7 @@ jobs:
   tests-unit:
     working_directory: ~/repo
     docker:
-      - image: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:7.0"
+      - image: &default-dotnet-image "mcr.microsoft.com/dotnet/sdk:8.0"
     steps:
       - client-test:
           project: "Client.Test"

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ commands:
     parameters:
       project:
         type: string
+      net-version:
+        type: string
     steps:
       - checkout
       - run:
@@ -18,12 +20,12 @@ commands:
             mkdir test-results
       - run:
           name: Run tests
-          command: dotnet test << parameters.project >> --collect "Xplat Code Coverage" --logger "junit;LogFilePath=../test-results/test-result.xml"
+          command: dotnet test "<< parameters.project >>/bin/Debug/net<< parameters.net-version >>/InfluxDB3.<< parameters.project >>.dll" --collect "Xplat Code Coverage" --logger "junit;LogFilePath=../test-results/test-result.xml"
       - run:
           name: Coverage Report
           command: |
             dotnet tool install --tool-path="./reportgenerator/" dotnet-reportgenerator-globaltool
-            ./reportgenerator/reportgenerator -reports:"./*/TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
+            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>/TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
             mv report/summary.html /tmp/artifacts
             cp test-results/test-result.xml /tmp/artifacts
           when: always
@@ -60,7 +62,8 @@ jobs:
       - image: << parameters.net-image >>
     steps:
       - client-test:
-          project: "Client.Test/bin/Debug/net<< parameters.net-version >>/InfluxDB3.Client.Test.dll"
+          project: "Client.Test"
+          net-version: << parameters.net-version >>
   tests-integration:
     working_directory: ~/repo
     parameters:
@@ -74,7 +77,8 @@ jobs:
       - image: << parameters.net-image >>
     steps:
       - client-test:
-          project: "Client.Test.Integration/bin/Debug/net<< parameters.net-version >>/InfluxDB3.Client.Test.Integration.dll"
+          project: "Client.Test.Integration"
+          net-version: << parameters.net-version >>
           
   check-compilation-warnings:
     docker:

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           name: Coverage Report
           command: |
             dotnet tool install --tool-path="./reportgenerator/" dotnet-reportgenerator-globaltool
-            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>/../../../../TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
+            ./reportgenerator/reportgenerator -reports:"./*/TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
             mv report/summary.html /tmp/artifacts
             cp test-results/test-result.xml /tmp/artifacts
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -23,7 +23,7 @@ commands:
           name: Coverage Report
           command: |
             dotnet tool install --tool-path="./reportgenerator/" dotnet-reportgenerator-globaltool
-            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>../../../../TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
+            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>/../../../../TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
             mv report/summary.html /tmp/artifacts
             cp test-results/test-result.xml /tmp/artifacts
           when: always

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,7 +4,6 @@ commands:
     parameters:
       project:
         type: string
-        default: "Client.Test"
     steps:
       - checkout
       - run:
@@ -24,7 +23,7 @@ commands:
           name: Coverage Report
           command: |
             dotnet tool install --tool-path="./reportgenerator/" dotnet-reportgenerator-globaltool
-            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>/TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
+            ./reportgenerator/reportgenerator -reports:"<< parameters.project >>../../../../TestResults/*/coverage.cobertura.xml" -targetdir:"report" -reporttypes:HtmlSummary "-sourcedirs:Client/"
             mv report/summary.html /tmp/artifacts
             cp test-results/test-result.xml /tmp/artifacts
           when: always

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.5.0 [unreleased]
 
+### Others
+
+1. [#80](https://github.com/InfluxCommunity/influxdb3-csharp/pull/80): Use net8.0 as a default target framework in Tests and Examples
+
 ## 0.4.0 [2023-12-08]
 
 ### Features

--- a/Client.Test.Integration/Client.Test.Integration.csproj
+++ b/Client.Test.Integration/Client.Test.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 

--- a/Client.Test.Integration/Client.Test.Integration.csproj
+++ b/Client.Test.Integration/Client.Test.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>10</LangVersion>
 
         <IsPackable>false</IsPackable>

--- a/Client.Test/Client.Test.csproj
+++ b/Client.Test/Client.Test.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
 
         <IsPackable>false</IsPackable>

--- a/Examples/Downsampling/Downsampling.csproj
+++ b/Examples/Downsampling/Downsampling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
 

--- a/Examples/Downsampling/Downsampling.csproj
+++ b/Examples/Downsampling/Downsampling.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net7.0</TargetFramework>
+    <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
 

--- a/Examples/IOx/Examples.IOx.csproj
+++ b/Examples/IOx/Examples.IOx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
+        <TargetFramework>net8.0</TargetFramework>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 

--- a/Examples/IOx/Examples.IOx.csproj
+++ b/Examples/IOx/Examples.IOx.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
     <PropertyGroup>
-        <TargetFramework>net7.0</TargetFramework>
+        <TargetFrameworks>net7.0;net8.0</TargetFrameworks>
         <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
 


### PR DESCRIPTION
## Proposed Changes

Add supports for net8.0 in tests and examples.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
