### PR TITLE
feat: custom headers can be specified for queries/writes

### DIFF
--- a/.github/ISSUE_TEMPLATE/SUPPORT.yml
+++ b/.github/ISSUE_TEMPLATE/SUPPORT.yml
@@ -8,7 +8,7 @@ body:
         WOAHH, hold up. This isn't the best place for support questions. 
         You can get a faster response on slack or forums:
 
-        Please redirect any QUESTIONS about Telegraf usage to 
+        Please redirect any QUESTIONS about Client usage to 
         - InfluxData Slack Channel: https://app.slack.com/huddle/TH8RGQX5Z/C02UDUPLQKA
         - InfluxData Community Site: https://community.influxdata.com
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.6.0 [unreleased]
 
+### Features
+
+1. [#90](https://github.com/InfluxCommunity/influxdb3-csharp/pull/90): Custom `HTTP/gRPC` headers can be specified globally by config or per request
+
 ## 0.5.0 [2024-03-01]
 
 ### Features

--- a/Client.Test/InfluxDBClientWriteTest.cs
+++ b/Client.Test/InfluxDBClientWriteTest.cs
@@ -340,7 +340,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             Assert.That(requests[0].RequestMessage.Headers?["X-device"].First(), Is.EqualTo("ab-01"));
         });
     }
-    
+
     [Test]
     public async Task CustomHeaderFromRequest()
     {
@@ -369,7 +369,7 @@ public class InfluxDBClientWriteTest : MockServerTest
         Assert.That(requests, Has.Count.EqualTo(1));
         Assert.That(requests[0].RequestMessage.Headers?["X-Tracing-ID"].First(), Is.EqualTo("123"));
     }
-    
+
     [Test]
     public async Task CustomHeaderFromRequestArePreferred()
     {

--- a/Client.Test/InfluxDBClientWriteTest.cs
+++ b/Client.Test/InfluxDBClientWriteTest.cs
@@ -286,7 +286,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             Token = "my-token",
             Organization = "my-org",
             Database = "my-database",
-            Proxy = new System.Net.WebProxy
+            Proxy = new WebProxy
             {
                 Address = new Uri(MockProxyUrl),
                 BypassProxyOnLocal = false
@@ -333,7 +333,74 @@ public class InfluxDBClientWriteTest : MockServerTest
         await _client.WritePointAsync(point);
 
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.BodyData?.BodyAsString, Is.EqualTo("h2o,location=europe level=2i 123000000000"));
+        Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.Multiple(() =>
+        {
+            Assert.That(requests[0].RequestMessage.BodyData?.BodyAsString, Is.EqualTo("h2o,location=europe level=2i 123000000000"));
+            Assert.That(requests[0].RequestMessage.Headers?["X-device"].First(), Is.EqualTo("ab-01"));
+        });
+    }
+    
+    [Test]
+    public async Task CustomHeaderFromRequest()
+    {
+        _client = new InfluxDBClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+            Token = "my-token",
+            Organization = "my-org",
+            Database = "my-database"
+        });
+        MockServer
+            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("X-Tracing-ID", "123").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var point = PointData.Measurement("h2o")
+            .SetTag("location", "europe")
+            .SetField("level", 2)
+            .SetTimestamp(123_000_000_000L);
+
+        await _client.WritePointAsync(point, headers: new Dictionary<string, string>
+        {
+            { "X-Tracing-ID", "123" },
+        });
+
+        var requests = MockServer.LogEntries.ToList();
+        Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.That(requests[0].RequestMessage.Headers?["X-Tracing-ID"].First(), Is.EqualTo("123"));
+    }
+    
+    [Test]
+    public async Task CustomHeaderFromRequestArePreferred()
+    {
+        _client = new InfluxDBClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+            Token = "my-token",
+            Organization = "my-org",
+            Database = "my-database",
+            Headers = new Dictionary<string, string>
+            {
+                { "X-Client-ID", "123" },
+            }
+        });
+        MockServer
+            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("X-Client-ID", "456").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        var point = PointData.Measurement("h2o")
+            .SetTag("location", "europe")
+            .SetField("level", 2)
+            .SetTimestamp(123_000_000_000L);
+
+        await _client.WritePointAsync(point, headers: new Dictionary<string, string>
+        {
+            { "X-Client-ID", "456" },
+        });
+
+        var requests = MockServer.LogEntries.ToList();
+        Assert.That(requests, Has.Count.EqualTo(1));
+        Assert.That(requests[0].RequestMessage.Headers?["X-Client-ID"].First(), Is.EqualTo("456"));
     }
 
     private async Task WriteData()

--- a/Client.Test/MockServerTest.cs
+++ b/Client.Test/MockServerTest.cs
@@ -36,7 +36,7 @@ public class MockServerTest
         MockProxyUrl = MockProxy.Urls[0];
     }
 
-    [OneTimeTearDownAttribute]
+    [OneTimeTearDown]
     public void OneTimeTearDownAttribute()
     {
         MockServer.Dispose();

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -111,9 +111,24 @@ public class ClientConfig
     public string? Database { get; set; }
 
     /// <summary>
-    /// The set of HTTP headers to be included in requests.
+    /// The custom headers that will be added to requests. This is useful for adding custom headers to requests,
+    /// such as tracing headers. To add custom headers use following code:
+    ///
+    /// <code>
+    /// using var client = new InfluxDBClient(new ClientConfig
+    /// {
+    ///     Host = "https://us-east-1-1.aws.cloud2.influxdata.com",
+    ///     Token = "my-token",
+    ///     Organization = "my-org",
+    ///     Database = "my-database",
+    ///     Headers = new Dictionary&lt;string, string&gt;
+    ///     {
+    ///         { "X-Tracing-Id", "123" },
+    ///     }
+    /// });
+    /// </code>
     /// </summary>
-    public Dictionary<String, String>? Headers { get; set; }
+    public Dictionary<string, string>? Headers { get; set; }
 
     /// <summary>
     /// Timeout to wait before the HTTP request times out. Default to '10 seconds'.

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -19,7 +19,8 @@ namespace InfluxDB3.Client
     {
         /// <summary>
         /// Query data from InfluxDB IOx using FlightSQL.
-        ///
+        /// </summary>
+        /// 
         /// <example>
         /// The following example shows how to use SQL query with named parameters:
         ///
@@ -32,33 +33,16 @@ namespace InfluxDB3.Client
         /// );
         /// </code>
         /// </example>
-        /// </summary>
-        /// <param name="query">The SQL query string to execute.</param>
-        /// <param name="queryType">The type of query sent to InfluxDB. Default to 'SQL'.</param>
-        /// <param name="database">The database to be used for InfluxDB operations.</param>
-        /// <param name="namedParameters">
-        ///     Name:Value pairs to use as named parameters for this query. Parameters referenced using
-        ///     '$placeholder' syntax in the query will be substituted with the values provided.
-        ///     The supported types are: string, bool, int, float.
-        /// </param>
-        /// <returns>Batches of rows</returns>
-        /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
-        IAsyncEnumerable<object?[]> Query(string query, QueryType? queryType = null, string? database = null,
-            Dictionary<string, object>? namedParameters = null);
-
-        /// <summary>
-        /// Query data from InfluxDB IOx using FlightSQL.
-        /// </summary>
-        ///
+        /// 
         /// <example>
-        /// The following example shows how to use SQL query with named parameters:
+        /// The following example shows how to use custom request headers:
         ///
         /// <code>
         /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
-        /// var results = client.QueryBatches(
-        ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
-        ///     namedParameters: new Dictionary&lt;string, object&gt; { { "id", 1 }, { "name", "test" } }
+        /// var results = client.Query(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
         /// );
         /// </code>
         /// </example>
@@ -70,10 +54,60 @@ namespace InfluxDB3.Client
         ///     '$placeholder' syntax in the query will be substituted with the values provided.
         ///     The supported types are: string, bool, int, float.
         /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
+        /// <returns>Batches of rows</returns>
+        /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
+        IAsyncEnumerable<object?[]> Query(string query, QueryType? queryType = null, string? database = null,
+            Dictionary<string, object>? namedParameters = null, Dictionary<string, string>? headers = null);
+
+        /// <summary>
+        /// Query data from InfluxDB IOx using FlightSQL.
+        /// </summary>
+        /// 
+        /// <example>
+        /// The following example shows how to use SQL query with named parameters:
+        /// 
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.QueryBatches(
+        ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
+        ///     namedParameters: new Dictionary&lt;string, object&gt; { { "id", 1 }, { "name", "test" } }
+        /// );
+        /// </code>
+        /// </example>
+        /// 
+        /// <example>
+        /// The following example shows how to use custom request headers:
+        /// 
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.QueryBatches(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
+        /// <param name="query">The SQL query string to execute.</param>
+        /// <param name="queryType">The type of query sent to InfluxDB. Default to 'SQL'.</param>
+        /// <param name="database">The database to be used for InfluxDB operations.</param>
+        /// <param name="namedParameters">
+        ///     Name:Value pairs to use as named parameters for this query. Parameters referenced using
+        ///     '$placeholder' syntax in the query will be substituted with the values provided.
+        ///     The supported types are: string, bool, int, float.
+        /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         IAsyncEnumerable<RecordBatch> QueryBatches(string query, QueryType? queryType = null, string? database = null,
-            Dictionary<string, object>? namedParameters = null);
+            Dictionary<string, object>? namedParameters = null, Dictionary<string, string>? headers = null);
 
         /// <summary>
         /// Query data from InfluxDB IOx into PointData structure using FlightSQL.
@@ -91,6 +125,18 @@ namespace InfluxDB3.Client
         /// );
         /// </code>
         /// </example>
+        /// <example>
+        /// The following example shows how to use custom request headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.QueryPoints(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="query">The SQL query string to execute.</param>
         /// <param name="queryType">The type of query sent to InfluxDB. Default to 'SQL'.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
@@ -99,10 +145,15 @@ namespace InfluxDB3.Client
         ///     '$placeholder' syntax in the query will be substituted with the values provided.
         ///     The supported types are: string, bool, int, float.
         /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         IAsyncEnumerable<PointDataValues> QueryPoints(string query, QueryType? queryType = null,
-            string? database = null, Dictionary<string, object>? namedParameters = null);
+            string? database = null, Dictionary<string, object>? namedParameters = null,
+            Dictionary<string, string>? headers = null);
 
         /// <summary>
         /// Write data to InfluxDB.
@@ -294,6 +345,19 @@ namespace InfluxDB3.Client
         /// );
         /// </code>
         /// </example>
+        /// 
+        /// <example>
+        /// The following example shows how to use custom request headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.Query(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="query">The SQL query string to execute.</param>
         /// <param name="queryType">The type of query sent to InfluxDB. Default to 'SQL'.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
@@ -302,12 +366,17 @@ namespace InfluxDB3.Client
         ///     '$placeholder' syntax in the query will be substituted with the values provided.
         ///     The supported types are: string, bool, int, float.
         /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         public async IAsyncEnumerable<object?[]> Query(string query, QueryType? queryType = null,
-            string? database = null, Dictionary<string, object>? namedParameters = null)
+            string? database = null, Dictionary<string, object>? namedParameters = null,
+            Dictionary<string, string>? headers = null)
         {
-            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters).ConfigureAwait(false))
+            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers).ConfigureAwait(false))
             {
                 var rowCount = batch.Column(0).Length;
                 for (var i = 0; i < rowCount; i++)
@@ -342,6 +411,18 @@ namespace InfluxDB3.Client
         /// );
         /// </code>
         /// </example>
+        /// <example>
+        /// The following example shows how to use custom request headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.QueryPoints(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="query">The SQL query string to execute.</param>
         /// <param name="queryType">The type of query sent to InfluxDB. Default to 'SQL'.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
@@ -350,12 +431,16 @@ namespace InfluxDB3.Client
         ///     '$placeholder' syntax in the query will be substituted with the values provided.
         ///     The supported types are: string, bool, int, float.
         /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         public async IAsyncEnumerable<PointDataValues> QueryPoints(string query, QueryType? queryType = null,
-            string? database = null, Dictionary<string, object>? namedParameters = null)
+            string? database = null, Dictionary<string, object>? namedParameters = null, Dictionary<string, string>? headers = null)
         {
-            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters).ConfigureAwait(false))
+            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers).ConfigureAwait(false))
             {
                 var rowCount = batch.Column(0).Length;
                 for (var i = 0; i < rowCount; i++)
@@ -419,16 +504,29 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Query data from InfluxDB IOx using FlightSQL.
         /// </summary>
-        ///
+        /// 
         /// <example>
         /// The following example shows how to use SQL query with named parameters:
-        ///
+        /// 
         /// <code>
         /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryBatches(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
         ///     namedParameters: new Dictionary&lt;string, object&gt; { { "id", 1 }, { "name", "test" } }
+        /// );
+        /// </code>
+        /// </example>
+        /// 
+        /// <example>
+        /// The following example shows how to use custom request headers:
+        /// 
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// 
+        /// var results = client.QueryBatches(
+        ///     query: "SELECT a, b, c FROM my_table",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
         /// );
         /// </code>
         /// </example>
@@ -440,10 +538,15 @@ namespace InfluxDB3.Client
         ///     '$placeholder' syntax in the query will be substituted with the values provided.
         ///     The supported types are: string, bool, int, float.
         /// </param>
+        /// <param name="headers">
+        ///     The headers to be added to query request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         public IAsyncEnumerable<RecordBatch> QueryBatches(string query, QueryType? queryType = null,
-            string? database = null, Dictionary<string, object>? namedParameters = null)
+            string? database = null, Dictionary<string, object>? namedParameters = null,
+            Dictionary<string, string>? headers = null)
         {
             if (_disposed)
             {
@@ -453,7 +556,8 @@ namespace InfluxDB3.Client
             return FlightSqlClient.Execute(query,
                 (database ?? _config.Database) ?? throw new InvalidOperationException(OptionMessage("database")),
                 queryType ?? QueryType.SQL,
-                namedParameters ?? new Dictionary<string, object>());
+                namedParameters ?? new Dictionary<string, object>(),
+                headers ?? new Dictionary<string, string>());
         }
 
         /// <summary>

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -158,6 +158,19 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write a single record with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WriteRecordAsync(
+        ///     record: "stat,unit=temperature value=24.5",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="record">Specifies the record in InfluxDB Line Protocol. The <see cref="record" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -166,12 +179,25 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null, 
+        Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null,
             Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write multiple records with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WriteRecordsAsync(
+        ///     records: new[] { "stat,unit=temperature value=24.5", "stat,unit=temperature value=25.5" },
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="records">Specifies the records in InfluxDB Line Protocol. The <see cref="records" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -180,12 +206,24 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WriteRecordsAsync(IEnumerable<string> records, string? database = null, WritePrecision? precision = null, 
+        Task WriteRecordsAsync(IEnumerable<string> records, string? database = null, WritePrecision? precision = null,
             Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write a single point with custom headers:
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WritePointAsync(
+        ///     point: PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="point">Specifies the Data point to write into InfluxDB. The <see cref="point" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -200,6 +238,22 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write multiple points with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WritePointsAsync(
+        ///     points: new[]{
+        ///         PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
+        ///         PointData.Measurement("h2o").SetTag("location", "us-west").SetField("level", 4),
+        ///     },
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="points">Specifies the Data points to write into InfluxDB. The <see cref="points" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -208,7 +262,7 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WritePointsAsync(IEnumerable<PointData> points, string? database = null, WritePrecision? precision = null, 
+        Task WritePointsAsync(IEnumerable<PointData> points, string? database = null, WritePrecision? precision = null,
             Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
     }
 
@@ -392,7 +446,8 @@ namespace InfluxDB3.Client
             string? database = null, Dictionary<string, object>? namedParameters = null,
             Dictionary<string, string>? headers = null)
         {
-            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers).ConfigureAwait(false))
+            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers)
+                               .ConfigureAwait(false))
             {
                 var rowCount = batch.Column(0).Length;
                 for (var i = 0; i < rowCount; i++)
@@ -454,9 +509,11 @@ namespace InfluxDB3.Client
         /// <returns>Batches of rows</returns>
         /// <exception cref="ObjectDisposedException">The client is already disposed</exception>
         public async IAsyncEnumerable<PointDataValues> QueryPoints(string query, QueryType? queryType = null,
-            string? database = null, Dictionary<string, object>? namedParameters = null, Dictionary<string, string>? headers = null)
+            string? database = null, Dictionary<string, object>? namedParameters = null,
+            Dictionary<string, string>? headers = null)
         {
-            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers).ConfigureAwait(false))
+            await foreach (var batch in QueryBatches(query, queryType, database, namedParameters, headers)
+                               .ConfigureAwait(false))
             {
                 var rowCount = batch.Column(0).Length;
                 for (var i = 0; i < rowCount; i++)
@@ -579,6 +636,20 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write a single record with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WriteRecordAsync(
+        ///     record: "stat,unit=temperature value=24.5",
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
+        /// 
         /// <param name="record">Specifies the record in InfluxDB Line Protocol. The <see cref="record" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -587,7 +658,7 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null, 
+        public Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null,
             Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
         {
             return WriteRecordsAsync(new[] { record }, database, precision, headers, cancellationToken);
@@ -596,6 +667,19 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write multiple records with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WriteRecordsAsync(
+        ///     records: new[] { "stat,unit=temperature value=24.5", "stat,unit=temperature value=25.5" },
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="records">Specifies the records in InfluxDB Line Protocol. The <see cref="records" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -604,7 +688,7 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WriteRecordsAsync(IEnumerable<string> records, string? database = null, 
+        public Task WriteRecordsAsync(IEnumerable<string> records, string? database = null,
             WritePrecision? precision = null, Dictionary<string, string>? headers = null,
             CancellationToken cancellationToken = default)
         {
@@ -614,6 +698,18 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write a single point with custom headers:
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WritePointAsync(
+        ///     point: PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example>
         /// <param name="point">Specifies the Data point to write into InfluxDB. The <see cref="point" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -622,7 +718,7 @@ namespace InfluxDB3.Client
         ///     the headers specified in the client configuration.
         /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WritePointAsync(PointData point, string? database = null, WritePrecision? precision = null, 
+        public Task WritePointAsync(PointData point, string? database = null, WritePrecision? precision = null,
             Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
         {
             return WritePointsAsync(new[] { point }, database, precision, headers, cancellationToken);
@@ -631,6 +727,22 @@ namespace InfluxDB3.Client
         /// <summary>
         /// Write data to InfluxDB.
         /// </summary>
+        ///
+        /// <example>
+        /// The following example shows how to write multiple points with custom headers:
+        ///
+        /// <code>
+        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        ///
+        /// await client.WritePointsAsync(
+        ///     points: new[]{
+        ///         PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
+        ///         PointData.Measurement("h2o").SetTag("location", "us-west").SetField("level", 4),
+        ///     },
+        ///     headers: new Dictionary&lt;string, string&gt; { { "X-Tracing-Id", "123" } }
+        /// );
+        /// </code>
+        /// </example> 
         /// <param name="points">Specifies the Data points to write into InfluxDB. The <see cref="points" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
@@ -646,8 +758,8 @@ namespace InfluxDB3.Client
             return WriteData(points, database, precision, headers, cancellationToken);
         }
 
-        private async Task WriteData(IEnumerable<object> data, string? database = null, 
-            WritePrecision? precision = null, Dictionary<string, string>? headers = null, 
+        private async Task WriteData(IEnumerable<object> data, string? database = null,
+            WritePrecision? precision = null, Dictionary<string, string>? headers = null,
             CancellationToken cancellationToken = default)
         {
             if (_disposed)

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -161,9 +161,13 @@ namespace InfluxDB3.Client
         /// <param name="record">Specifies the record in InfluxDB Line Protocol. The <see cref="record" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WriteRecordAsync(string record, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default);
+        Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null, 
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write data to InfluxDB.
@@ -171,9 +175,13 @@ namespace InfluxDB3.Client
         /// <param name="records">Specifies the records in InfluxDB Line Protocol. The <see cref="records" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WriteRecordsAsync(IEnumerable<string> records, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default);
+        Task WriteRecordsAsync(IEnumerable<string> records, string? database = null, WritePrecision? precision = null, 
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write data to InfluxDB.
@@ -181,9 +189,13 @@ namespace InfluxDB3.Client
         /// <param name="point">Specifies the Data point to write into InfluxDB. The <see cref="point" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WritePointAsync(PointData point, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default);
+        Task WritePointAsync(PointData point, string? database = null, WritePrecision? precision = null,
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
 
         /// <summary>
         /// Write data to InfluxDB.
@@ -191,9 +203,13 @@ namespace InfluxDB3.Client
         /// <param name="points">Specifies the Data points to write into InfluxDB. The <see cref="points" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        Task WritePointsAsync(IEnumerable<PointData> points, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default);
+        Task WritePointsAsync(IEnumerable<PointData> points, string? database = null, WritePrecision? precision = null, 
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default);
     }
 
     public class InfluxDBClient : IInfluxDBClient
@@ -566,11 +582,15 @@ namespace InfluxDB3.Client
         /// <param name="record">Specifies the record in InfluxDB Line Protocol. The <see cref="record" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WriteRecordAsync(string record, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default)
+        public Task WriteRecordAsync(string record, string? database = null, WritePrecision? precision = null, 
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
         {
-            return WriteRecordsAsync(new[] { record }, database, precision, cancellationToken);
+            return WriteRecordsAsync(new[] { record }, database, precision, headers, cancellationToken);
         }
 
         /// <summary>
@@ -579,11 +599,16 @@ namespace InfluxDB3.Client
         /// <param name="records">Specifies the records in InfluxDB Line Protocol. The <see cref="records" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WriteRecordsAsync(IEnumerable<string> records, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default)
+        public Task WriteRecordsAsync(IEnumerable<string> records, string? database = null, 
+            WritePrecision? precision = null, Dictionary<string, string>? headers = null,
+            CancellationToken cancellationToken = default)
         {
-            return WriteData(records, database, precision, cancellationToken);
+            return WriteData(records, database, precision, headers, cancellationToken);
         }
 
         /// <summary>
@@ -592,11 +617,15 @@ namespace InfluxDB3.Client
         /// <param name="point">Specifies the Data point to write into InfluxDB. The <see cref="point" /> is considered as one batch unit. </param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
-        public Task WritePointAsync(PointData point, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default)
+        public Task WritePointAsync(PointData point, string? database = null, WritePrecision? precision = null, 
+            Dictionary<string, string>? headers = null, CancellationToken cancellationToken = default)
         {
-            return WritePointsAsync(new[] { point }, database, precision, cancellationToken);
+            return WritePointsAsync(new[] { point }, database, precision, headers, cancellationToken);
         }
 
         /// <summary>
@@ -605,15 +634,21 @@ namespace InfluxDB3.Client
         /// <param name="points">Specifies the Data points to write into InfluxDB. The <see cref="points" /> is considered as one batch unit.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <param name="precision">The to use for the timestamp in the write API call.</param>
+        /// <param name="headers">
+        ///     The headers to be added to write request. The headers specified here are preferred over
+        ///     the headers specified in the client configuration.
+        /// </param>
         /// <param name="cancellationToken">specifies the token to monitor for cancellation requests.</param>
         public Task WritePointsAsync(IEnumerable<PointData> points, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default)
+            WritePrecision? precision = null, Dictionary<string, string>? headers = null,
+            CancellationToken cancellationToken = default)
         {
-            return WriteData(points, database, precision, cancellationToken);
+            return WriteData(points, database, precision, headers, cancellationToken);
         }
 
-        private async Task WriteData(IEnumerable<object> data, string? database = null,
-            WritePrecision? precision = null, CancellationToken cancellationToken = default)
+        private async Task WriteData(IEnumerable<object> data, string? database = null, 
+            WritePrecision? precision = null, Dictionary<string, string>? headers = null, 
+            CancellationToken cancellationToken = default)
         {
             if (_disposed)
             {
@@ -645,7 +680,7 @@ namespace InfluxDB3.Client
             };
 
             await _restClient
-                .Request("api/v2/write", HttpMethod.Post, content, queryParams, cancellationToken)
+                .Request("api/v2/write", HttpMethod.Post, content, queryParams, headers, cancellationToken)
                 .ConfigureAwait(false);
         }
 
@@ -715,13 +750,6 @@ namespace InfluxDB3.Client
             {
                 Timeout = config.Timeout
             };
-            if (config.Headers != null)
-            {
-                foreach (var header in config.Headers)
-                {
-                    client.DefaultRequestHeaders.Add(header.Key, header.Value);
-                }
-            }
 
             client.DefaultRequestHeaders.UserAgent.ParseAdd($"influxdb3-csharp/{AssemblyHelper.GetVersion()}");
             if (!string.IsNullOrEmpty(config.Token))

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.IO;
+using System.Linq;
 using System.Net.Http;
 using System.Runtime.Serialization;
 using System.Runtime.Serialization.Json;
@@ -24,13 +25,20 @@ internal interface IFlightSqlClient : IDisposable
     /// Execute the query and return the result as a sequence of record batches.
     /// </summary>
     internal IAsyncEnumerable<RecordBatch> Execute(string query, string database, QueryType queryType,
-        Dictionary<string, object> namedParameters);
+        Dictionary<string, object> namedParameters, Dictionary<string, string> headers);
 
     /// <summary>
     /// Prepare the FlightTicket for the query.
     /// </summary>
     internal FlightTicket PrepareFlightTicket(string query, string database, QueryType queryType,
         Dictionary<string, object> namedParameters);
+
+    /// <summary>
+    /// Prepare the headers metadata.
+    /// </summary>
+    /// <param name="headers">The invocation headers</param>
+    /// <returns></returns>
+    internal Metadata PrepareHeadersMetadata(Dictionary<string, string> headers);
 }
 
 internal class FlightSqlClient : IFlightSqlClient
@@ -66,7 +74,7 @@ internal class FlightSqlClient : IFlightSqlClient
     }
 
     async IAsyncEnumerable<RecordBatch> IFlightSqlClient.Execute(string query, string database, QueryType queryType,
-        Dictionary<string, object> namedParameters)
+        Dictionary<string, object> namedParameters, Dictionary<string, string> headers)
     {
         //
         // verify that values of namedParameters is supported type
@@ -82,16 +90,11 @@ internal class FlightSqlClient : IFlightSqlClient
             }
         }
 
-        var headers = new Metadata();
-        // authorization by token
-        if (!string.IsNullOrEmpty(_config.Token))
-        {
-            headers.Add("Authorization", $"Bearer {_config.Token}");
-        }
+        var metadata = ((IFlightSqlClient)this).PrepareHeadersMetadata(headers);
 
         var ticket = ((IFlightSqlClient)this).PrepareFlightTicket(query, database, queryType, namedParameters);
 
-        using var stream = _flightClient.GetStream(ticket, headers);
+        using var stream = _flightClient.GetStream(ticket, metadata);
         while (await stream.ResponseStream.MoveNext().ConfigureAwait(false))
         {
             yield return stream.ResponseStream.Current;
@@ -123,6 +126,31 @@ internal class FlightSqlClient : IFlightSqlClient
 
         var flightTicket = new FlightTicket(json);
         return flightTicket;
+    }
+
+    Metadata IFlightSqlClient.PrepareHeadersMetadata(Dictionary<string, string> headers)
+    {
+        var metadata = new Metadata();
+        // authorization by token
+        if (!string.IsNullOrEmpty(_config.Token))
+        {
+            metadata.Add("Authorization", $"Bearer {_config.Token}");
+        }
+
+        // add request headers
+        foreach (var header in headers)
+        {
+            metadata.Add(header.Key, header.Value);
+        }
+        // add global headers
+        if (_config.Headers != null)
+        {
+            foreach (var header in _config.Headers.Where(header => !headers.ContainsKey(header.Key)))
+            {
+                metadata.Add(header.Key, header.Value);
+            }
+        }
+        return metadata;
     }
 
     private string SerializeDictionary(Dictionary<string, object> ticketData)

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -142,7 +142,7 @@ internal class FlightSqlClient : IFlightSqlClient
         {
             metadata.Add(header.Key, header.Value);
         }
-        // add global headers
+        // add config headers
         if (_config.Headers != null)
         {
             foreach (var header in _config.Headers.Where(header => !headers.ContainsKey(header.Key)))

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -66,7 +66,7 @@ internal class RestClient
                 request.Headers.Add(header.Key, header.Value);
             }
         }
-        
+
         // add config headers
         if (_config.Headers != null)
         {

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -29,7 +29,7 @@ internal class RestClient
     }
 
     internal async Task Request(string path, HttpMethod method, HttpContent? content = null,
-        Dictionary<string, string?>? queryParams = null,
+        Dictionary<string, string?>? queryParams = null, Dictionary<string, string>? headers = null,
         CancellationToken cancellationToken = default)
     {
         var builder = new UriBuilder(new Uri($"{_config.Host}{path}"));
@@ -58,6 +58,26 @@ internal class RestClient
             RequestUri = builder.Uri,
             Content = content,
         };
+        // add request headers
+        if (headers is not null)
+        {
+            foreach (var header in headers)
+            {
+                request.Headers.Add(header.Key, header.Value);
+            }
+        }
+        
+        // add config headers
+        if (_config.Headers != null)
+        {
+            foreach (var header in _config.Headers)
+            {
+                if (headers == null || !headers.ContainsKey(header.Key))
+                {
+                    request.Headers.Add(header.Key, header.Value);
+                }
+            }
+        }
 
         var result = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccessStatusCode)


### PR DESCRIPTION
## Proposed Changes

Custom `HTTP/gRPC` headers can be specified globally by config or per request.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
