### PR TITLE
feat: set User-Agent header in gRPC.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 0.7.0 [unreleased]
 
+### Features
+
+1. [#101](https://github.com/InfluxCommunity/influxdb3-csharp/pull/101): Add standard `user-agent` header to all calls.
+
 ## 0.6.0 [2024-04-16]
 
 ### Features

--- a/Client.Test/Internal/AssemblyHelperTest.cs
+++ b/Client.Test/Internal/AssemblyHelperTest.cs
@@ -18,5 +18,13 @@ namespace InfluxDB3.Client.Test.Internal
                 Assert.That(Version.Parse(version).Revision, Is.EqualTo(0));
             });
         }
+
+        [Test]
+        public void GetUserAgent()
+        {
+            var version = AssemblyHelper.GetVersion();
+            var userAgent = AssemblyHelper.GetUserAgent();
+            Assert.That(userAgent, Is.EqualTo($"influxdb3-csharp/{version}"));
+        }
     }
 }

--- a/Client.Test/Internal/FlightSqlClientTest.cs
+++ b/Client.Test/Internal/FlightSqlClientTest.cs
@@ -83,9 +83,11 @@ public class FlightSqlClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(prepareHeadersMetadata, Is.Not.Null);
-            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(1));
-            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("x-tracing-id"));
-            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo("987"));
+            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(2));
+            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("user-agent"));
+            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo(AssemblyHelper.GetUserAgent()));
+            Assert.That(prepareHeadersMetadata[1].Key, Is.EqualTo("x-tracing-id"));
+            Assert.That(prepareHeadersMetadata[1].Value, Is.EqualTo("987"));
         });
     }
 
@@ -112,9 +114,11 @@ public class FlightSqlClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(prepareHeadersMetadata, Is.Not.Null);
-            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(1));
-            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("x-global-tracing-id"));
-            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo("123"));
+            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(2));
+            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("user-agent"));
+            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo(AssemblyHelper.GetUserAgent()));
+            Assert.That(prepareHeadersMetadata[1].Key, Is.EqualTo("x-global-tracing-id"));
+            Assert.That(prepareHeadersMetadata[1].Value, Is.EqualTo("123"));
         });
     }
 
@@ -141,9 +145,41 @@ public class FlightSqlClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(prepareHeadersMetadata, Is.Not.Null);
-            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(1));
-            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("x-tracing-id"));
-            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo("258"));
+            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(2));
+            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("user-agent"));
+            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo(AssemblyHelper.GetUserAgent()));
+            Assert.That(prepareHeadersMetadata[1].Key, Is.EqualTo("x-tracing-id"));
+            Assert.That(prepareHeadersMetadata[1].Value, Is.EqualTo("258"));
         });
     }
+
+    [Test]
+    public void UserAgentHeaderNotChanged()
+    {
+        _flightSqlClient.Dispose();
+
+        var config = new ClientConfig
+        {
+            Host = MockServerUrl,
+            Timeout = TimeSpan.FromSeconds(45),
+            Headers = new Dictionary<string, string>
+            {
+                { "User-Agent", "some/user-agent" }
+            }
+        };
+
+        _flightSqlClient = new FlightSqlClient(config, InfluxDBClient.CreateAndConfigureHttpClient(config));
+
+        var prepareHeadersMetadata =
+            _flightSqlClient.PrepareHeadersMetadata(new Dictionary<string, string> { { "user-agent", "another/user-agent" } });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(prepareHeadersMetadata, Is.Not.Null);
+            Assert.That(prepareHeadersMetadata, Has.Count.EqualTo(1));
+            Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("user-agent"));
+            Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo(AssemblyHelper.GetUserAgent()));
+        });
+    }
+
 }

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -863,7 +863,7 @@ namespace InfluxDB3.Client
                 Timeout = config.Timeout
             };
 
-            client.DefaultRequestHeaders.UserAgent.ParseAdd($"influxdb3-csharp/{AssemblyHelper.GetVersion()}");
+            client.DefaultRequestHeaders.UserAgent.ParseAdd(AssemblyHelper.GetUserAgent());
             if (!string.IsNullOrEmpty(config.Token))
             {
                 client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", config.Token);

--- a/Client/Internal/AssemblyHelper.cs
+++ b/Client/Internal/AssemblyHelper.cs
@@ -12,5 +12,11 @@ namespace InfluxDB3.Client.Internal
                 .GetCustomAttribute<AssemblyFileVersionAttribute>()
                 .Version;
         }
+
+        internal static string GetUserAgent()
+        {
+            return $"influxdb3-csharp/{GetVersion()}";
+        }
+
     }
 }

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -131,6 +131,10 @@ internal class FlightSqlClient : IFlightSqlClient
     Metadata IFlightSqlClient.PrepareHeadersMetadata(Dictionary<string, string> headers)
     {
         var metadata = new Metadata();
+
+        // user-agent
+        metadata.Add("user-agent", AssemblyHelper.GetUserAgent());
+
         // authorization by token
         if (!string.IsNullOrEmpty(_config.Token))
         {
@@ -138,7 +142,7 @@ internal class FlightSqlClient : IFlightSqlClient
         }
 
         // add request headers
-        foreach (var header in headers)
+        foreach (var header in headers.Where(header => !header.Key.ToLower().Equals("user-agent")))
         {
             metadata.Add(header.Key, header.Value);
         }
@@ -147,7 +151,10 @@ internal class FlightSqlClient : IFlightSqlClient
         {
             foreach (var header in _config.Headers.Where(header => !headers.ContainsKey(header.Key)))
             {
-                metadata.Add(header.Key, header.Value);
+                if (!header.Key.ToLower().Equals("user-agent"))
+                {
+                    metadata.Add(header.Key, header.Value);
+                }
             }
         }
         return metadata;


### PR DESCRIPTION
## Proposed Changes

1. Move setting UserAgent value to AssemblyHelper
2. Ensure the header is added to Metadata in FlightSqlClient
3. Add check for `user-agent` header in tests
4. Ensure that only 1 `user-agent` header can be defined per call, and that it is the default from AssemblyHelper

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
