### PR TITLE
feat: add Edge error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Features
 
 1. [#101](https://github.com/InfluxCommunity/influxdb3-csharp/pull/101): Add standard `user-agent` header to all calls.
+1. [#110](https://github.com/InfluxCommunity/influxdb3-csharp/pull/110): InfluxDB Edge (OSS) error handling.
 
 ## 0.6.0 [2024-04-16]
 

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -93,11 +93,16 @@ internal class RestClient
                     if (new DataContractJsonSerializer(typeof(ErrorBody)).ReadObject(memoryStream) is ErrorBody
                         errorBody)
                     {
-                        if (!string.IsNullOrEmpty(errorBody.Message)) { // Cloud
+                        if (!string.IsNullOrEmpty(errorBody.Message)) // Cloud
+                        {
                             message = errorBody.Message;
-                        } else if ((errorBody.Data is not null) && !string.IsNullOrEmpty(errorBody.Data.ErrorMessage)) { // Edge
+                        }
+                        else if ((errorBody.Data is not null) && !string.IsNullOrEmpty(errorBody.Data.ErrorMessage)) // Edge
+                        {
                             message = errorBody.Data.ErrorMessage;
-                        } else if (!string.IsNullOrEmpty(errorBody.Error)) { // Edge
+                        }
+                        else if (!string.IsNullOrEmpty(errorBody.Error)) // Edge
+                        {
                             message = errorBody.Error;
                         }
                     }

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -93,7 +93,13 @@ internal class RestClient
                     if (new DataContractJsonSerializer(typeof(ErrorBody)).ReadObject(memoryStream) is ErrorBody
                         errorBody)
                     {
-                        message = errorBody.Message;
+                        if (!string.IsNullOrEmpty(errorBody.Message)) { // Cloud
+                            message = errorBody.Message;
+                        } else if ((errorBody.Data is not null) && !string.IsNullOrEmpty(errorBody.Data.ErrorMessage)) { // Edge
+                            message = errorBody.Data.ErrorMessage;
+                        } else if (!string.IsNullOrEmpty(errorBody.Error)) { // Edge
+                            message = errorBody.Error;
+                        }
                     }
                 }
                 catch (SerializationException se)
@@ -131,5 +137,19 @@ internal class RestClient
 [DataContract]
 internal class ErrorBody
 {
-    [DataMember(Name = "message")] public string? Message { get; set; }
+    [DataMember(Name = "message")]
+    public string? Message { get; set; }
+
+    [DataMember(Name = "error")]
+    public string? Error { get; set; }
+
+    [DataMember(Name = "data")]
+    public ErrorData? Data { get; set; }
+
+    [DataContract]
+    internal class ErrorData
+    {
+        [DataMember(Name = "error_message")]
+        public string? ErrorMessage { get; set; }
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Extends error response processing to handle Edge (OSS) errors as well. It sets `InfluxDBApiException.Message` value from either `message` (Cloud) or `data.error_message` / `error` (Edge) element value in the response body when an error occurs.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)