### PR TITLE
feat: add Edge authentication support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@
 1. [#110](https://github.com/InfluxCommunity/influxdb3-csharp/pull/110): InfluxDB Edge (OSS) error handling.
 1. [#111](https://github.com/InfluxCommunity/influxdb3-csharp/pull/111): Add InfluxDB Edge (OSS) authentication support.
 
+### Migration Notice
+
+- `InfluxDBClient` constructor with connection options has new option `authScheme` with `null` default value:
+
+```diff
+- public InfluxDBClient(string host, string token, string? organization = null, string? database = null);
++ public InfluxDBClient(string host, string token, string? organization = null, string? database = null, string? authScheme = null)
+```
+  This new option is used for Edge (OSS) authentication.
+
 ## 0.6.0 [2024-04-16]
 
 ### Features

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 1. [#101](https://github.com/InfluxCommunity/influxdb3-csharp/pull/101): Add standard `user-agent` header to all calls.
 1. [#110](https://github.com/InfluxCommunity/influxdb3-csharp/pull/110): InfluxDB Edge (OSS) error handling.
+1. [#111](https://github.com/InfluxCommunity/influxdb3-csharp/pull/111): Add InfluxDB Edge (OSS) authentication support.
 
 ## 0.6.0 [2024-04-16]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@
 - public InfluxDBClient(string host, string token, string? organization = null, string? database = null);
 + public InfluxDBClient(string host, string token, string? organization = null, string? database = null, string? authScheme = null)
 ```
+
   This new option is used for Edge (OSS) authentication.
 
 ## 0.6.0 [2024-04-16]

--- a/Client.Test/Config/ClientConfigTest.cs
+++ b/Client.Test/Config/ClientConfigTest.cs
@@ -48,6 +48,21 @@ public class ClientConfigTest
     }
 
     [Test]
+    public void CreateFromConnectionStringWithAuthScheme()
+    {
+        var cfg = new ClientConfig("http://localhost:8086?token=my-token&org=my-org&authScheme=my-scheme");
+        Assert.That(cfg, Is.Not.Null);
+        cfg.Validate();
+        Assert.Multiple(() =>
+        {
+            Assert.That(cfg.Host, Is.EqualTo("http://localhost:8086/"));
+            Assert.That(cfg.Token, Is.EqualTo("my-token"));
+            Assert.That(cfg.AuthScheme, Is.EqualTo("my-scheme"));
+            Assert.That(cfg.WriteOptions, Is.EqualTo(null));
+        });
+    }
+
+    [Test]
     public void CreateFromConnectionStringWithWriteOptions()
     {
         var cfg = new ClientConfig("http://localhost:8086?token=my-token&org=my-org&database=my-database&precision=s&gzipThreshold=64");
@@ -139,6 +154,28 @@ public class ClientConfigTest
             Assert.That(cfg.Token, Is.EqualTo("my-token"));
             Assert.That(cfg.Organization, Is.EqualTo("my-org"));
             Assert.That(cfg.Database, Is.EqualTo("my-database"));
+            Assert.That(cfg.WriteOptions, Is.EqualTo(null));
+        });
+    }
+
+    [Test]
+    public void CreateFromEnvWithAuthScheme()
+    {
+        var env = new Dictionary<String, String>
+        {
+            {"INFLUX_HOST", "http://localhost:8086"},
+            {"INFLUX_TOKEN", "my-token"},
+            {"INFLUX_AUTH_SCHEME", "my-scheme"},
+        };
+        SetEnv(env);
+        var cfg = new ClientConfig(env);
+        Assert.That(cfg, Is.Not.Null);
+        cfg.Validate();
+        Assert.Multiple(() =>
+        {
+            Assert.That(cfg.Host, Is.EqualTo("http://localhost:8086/"));
+            Assert.That(cfg.Token, Is.EqualTo("my-token"));
+            Assert.That(cfg.AuthScheme, Is.EqualTo("my-scheme"));
             Assert.That(cfg.WriteOptions, Is.EqualTo(null));
         });
     }

--- a/Client.Test/Internal/RestClientTest.cs
+++ b/Client.Test/Internal/RestClientTest.cs
@@ -37,6 +37,22 @@ public class RestClientTest : MockServerTest
     }
 
     [Test]
+    public async Task AuthorizationCustomScheme()
+    {
+        CreateAndConfigureRestClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+            Token = "my-token",
+            AuthScheme = "my-scheme"
+        });
+        await DoRequest();
+
+        var requests = MockServer.LogEntries.ToList();
+
+        Assert.That(requests[0].RequestMessage.Headers?["Authorization"][0], Is.EqualTo("my-scheme my-token"));
+    }
+
+    [Test]
     public async Task UserAgent()
     {
         CreateAndConfigureRestClient(new ClientConfig

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -13,7 +13,7 @@ namespace InfluxDB3.Client.Config;
 /// You can configure following options:
 /// - Host: The URL of the InfluxDB server.
 /// - Token: The authentication token for accessing the InfluxDB server.
-/// - AuthScheme: Token authenication scheme. Default is 'null' for Cloud access. Set to 'Bearer' for Edge access.
+/// - AuthScheme: Token authentication scheme. Default is 'null' for Cloud access. Set to 'Bearer' for Edge access.
 /// - Organization: The organization to be used for operations.
 /// - Database: The database to be used for InfluxDB operations.
 /// - Headers: The set of HTTP headers to be included in requests.

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -13,6 +13,7 @@ namespace InfluxDB3.Client.Config;
 /// You can configure following options:
 /// - Host: The URL of the InfluxDB server.
 /// - Token: The authentication token for accessing the InfluxDB server.
+/// - AuthScheme: Token authenication scheme. Default is 'null' for Cloud access. Set to 'Bearer' for Edge access.
 /// - Organization: The organization to be used for operations.
 /// - Database: The database to be used for InfluxDB operations.
 /// - Headers: The set of HTTP headers to be included in requests.
@@ -44,6 +45,7 @@ public class ClientConfig
 {
     internal const string EnvInfluxHost = "INFLUX_HOST";
     internal const string EnvInfluxToken = "INFLUX_TOKEN";
+    internal const string EnvInfluxAuthScheme = "INFLUX_AUTH_SCHEME";
     internal const string EnvInfluxOrg = "INFLUX_ORG";
     internal const string EnvInfluxDatabase = "INFLUX_DATABASE";
     internal const string EnvInfluxPrecision = "INFLUX_PRECISION";
@@ -67,6 +69,7 @@ public class ClientConfig
         Host = uri.GetLeftPart(UriPartial.Path);
         var values = HttpUtility.ParseQueryString(uri.Query);
         Token = values.Get("token");
+        AuthScheme = values.Get("authScheme");
         Organization = values.Get("org");
         Database = values.Get("database");
         ParsePrecision(values.Get("precision"));
@@ -80,6 +83,7 @@ public class ClientConfig
     {
         Host = (string)env[EnvInfluxHost];
         Token = env[EnvInfluxToken] as string;
+        AuthScheme = env[EnvInfluxAuthScheme] as string;
         Organization = env[EnvInfluxOrg] as string;
         Database = env[EnvInfluxDatabase] as string;
         ParsePrecision(env[EnvInfluxPrecision] as string);
@@ -99,6 +103,11 @@ public class ClientConfig
     /// The authentication token for accessing the InfluxDB server.
     /// </summary>
     public string? Token { get; set; }
+
+    /// <summary>
+    /// Token authentication scheme.
+    /// </summary>
+    public string? AuthScheme { get; set; }
 
     /// <summary>
     /// The organization to be used for operations.

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -289,7 +289,7 @@ namespace InfluxDB3.Client
         /// <param name="organization">The organization name to be used for operations.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <example>
-       /// using var client = new InfluxDBClient(host: "https://us-east-1-1.aws.cloud2.influxdata.com", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "https://us-east-1-1.aws.cloud2.influxdata.com", token: "my-token", organization: "my-org", database: "my-database");
         /// </example>
         public InfluxDBClient(string host, string token, string? authScheme = null, string? organization = null,
             string? database = null) : this(

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -285,12 +285,13 @@ namespace InfluxDB3.Client
         /// </summary>
         /// <param name="host">The URL of the InfluxDB server.</param>
         /// <param name="token">The authentication token for accessing the InfluxDB server.</param>
+        /// <param name="authScheme">Token authentications scheme.</param>
         /// <param name="organization">The organization name to be used for operations.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <example>
         /// using var client = new InfluxDBClient("https://us-east-1-1.aws.cloud2.influxdata.com", "my-token", "my-org", "my-database");
         /// </example>
-        public InfluxDBClient(string host, string token, string? organization = null,
+        public InfluxDBClient(string host, string token, string? authScheme = null, string? organization = null,
             string? database = null) : this(
             new ClientConfig
             {
@@ -298,6 +299,7 @@ namespace InfluxDB3.Client
                 Organization = organization,
                 Database = database,
                 Token = token,
+                AuthScheme = authScheme,
                 WriteOptions = WriteOptions.DefaultOptions
             })
         {
@@ -343,6 +345,9 @@ namespace InfluxDB3.Client
         /// <description>token - authentication token (required)</description>
         /// </item>
         /// <item>
+        /// <description>authScheme - token authentication scheme (default <c>null</c> for Cloud access)</description>
+        /// </item>
+        /// <item>
         /// <description>org - organization name</description>
         /// </item>
         /// <item>
@@ -371,10 +376,13 @@ namespace InfluxDB3.Client
         /// Supported parameters are:
         /// <list type="bullet">
         /// <item>
-        /// <description>INFLUX_HOST - authentication token (required)</description>
+        /// <description>INFLUX_HOST - InfluxDB host URL (required)</description>
         /// </item>
         /// <item>
         /// <description>INFLUX_TOKEN - authentication token (required)</description>
+        /// </item>
+        /// <item>
+        /// <description>INFLUX_AUTH_SCHEME - token authentication scheme (default is <c>null</c> for Cloud access)</description>
         /// </item>
         /// <item>
         /// <description>INFLUX_ORG - organization name</description>
@@ -866,7 +874,8 @@ namespace InfluxDB3.Client
             client.DefaultRequestHeaders.UserAgent.ParseAdd(AssemblyHelper.GetUserAgent());
             if (!string.IsNullOrEmpty(config.Token))
             {
-                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Token", config.Token);
+                string authScheme = string.IsNullOrEmpty(config.AuthScheme) ? "Token" : config.AuthScheme;
+                client.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue(authScheme, config.Token);
             }
 
             return client;

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -25,7 +25,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.Query(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -38,7 +38,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.Query(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -71,7 +71,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         /// 
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryBatches(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -84,7 +84,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         /// 
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryBatches(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -117,7 +117,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryPoints(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -129,7 +129,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryPoints(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -163,7 +163,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write a single record with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WriteRecordAsync(
         ///     record: "stat,unit=temperature value=24.5",
@@ -190,7 +190,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write multiple records with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WriteRecordsAsync(
         ///     records: new[] { "stat,unit=temperature value=24.5", "stat,unit=temperature value=25.5" },
@@ -216,7 +216,7 @@ namespace InfluxDB3.Client
         /// <example>
         /// The following example shows how to write a single point with custom headers:
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WritePointAsync(
         ///     point: PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
@@ -243,7 +243,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write multiple points with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WritePointsAsync(
         ///     points: new[]{
@@ -285,14 +285,14 @@ namespace InfluxDB3.Client
         /// </summary>
         /// <param name="host">The URL of the InfluxDB server.</param>
         /// <param name="token">The authentication token for accessing the InfluxDB server.</param>
-        /// <param name="authScheme">Token authentications scheme.</param>
         /// <param name="organization">The organization name to be used for operations.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
+        /// <param name="authScheme">Token authentications scheme.</param>
         /// <example>
         /// using var client = new InfluxDBClient(host: "https://us-east-1-1.aws.cloud2.influxdata.com", token: "my-token", organization: "my-org", database: "my-database");
         /// </example>
-        public InfluxDBClient(string host, string token, string? authScheme = null, string? organization = null,
-            string? database = null) : this(
+        public InfluxDBClient(string host, string token, string? organization = null,
+            string? database = null, string? authScheme = null) : this(
             new ClientConfig
             {
                 Host = host,
@@ -364,7 +364,7 @@ namespace InfluxDB3.Client
         /// </summary>
         /// <param name="connectionString">Connection string in URL format.</param>
         /// <example>
-        /// using var client = new InfluxDBClient("https://us-east-1-1.aws.cloud2.influxdata.com?token=my-token&amp;database=my-db");
+        /// using var client = new InfluxDBClient(host: "https://us-east-1-1.aws.cloud2.influxdata.com?token=my-token&amp;database=my-db");
         /// </example>
         public InfluxDBClient(string connectionString) : this(new ClientConfig(connectionString))
         {
@@ -415,7 +415,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.Query(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -428,7 +428,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.Query(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -482,7 +482,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryPoints(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -494,7 +494,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryPoints(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -590,7 +590,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use SQL query with named parameters:
         /// 
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryBatches(
         ///     query: "SELECT a, b, c FROM my_table WHERE id = $id AND name = $name",
@@ -603,7 +603,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to use custom request headers:
         /// 
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         /// 
         /// var results = client.QueryBatches(
         ///     query: "SELECT a, b, c FROM my_table",
@@ -649,7 +649,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write a single record with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WriteRecordAsync(
         ///     record: "stat,unit=temperature value=24.5",
@@ -680,7 +680,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write multiple records with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WriteRecordsAsync(
         ///     records: new[] { "stat,unit=temperature value=24.5", "stat,unit=temperature value=25.5" },
@@ -710,7 +710,7 @@ namespace InfluxDB3.Client
         /// <example>
         /// The following example shows how to write a single point with custom headers:
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WritePointAsync(
         ///     point: PointData.Measurement("h2o").SetTag("location", "europe").SetField("level", 2),
@@ -740,7 +740,7 @@ namespace InfluxDB3.Client
         /// The following example shows how to write multiple points with custom headers:
         ///
         /// <code>
-        /// using var client = new InfluxDBClient("http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
+        /// using var client = new InfluxDBClient(host: "http://localhost:8086", token: "my-token", organization: "my-org", database: "my-database");
         ///
         /// await client.WritePointsAsync(
         ///     points: new[]{

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -289,7 +289,7 @@ namespace InfluxDB3.Client
         /// <param name="organization">The organization name to be used for operations.</param>
         /// <param name="database">The database to be used for InfluxDB operations.</param>
         /// <example>
-        /// using var client = new InfluxDBClient("https://us-east-1-1.aws.cloud2.influxdata.com", "my-token", "my-org", "my-database");
+       /// using var client = new InfluxDBClient(host: "https://us-east-1-1.aws.cloud2.influxdata.com", token: "my-token", organization: "my-org", database: "my-database");
         /// </example>
         public InfluxDBClient(string host, string token, string? authScheme = null, string? organization = null,
             string? database = null) : this(


### PR DESCRIPTION
## Proposed Changes

Adds `authScheme` option to `InfluxDBClient` initialization (via config, connection string or environment variables) to allow setting token authentication scheme other then the default `"Token"` (used for Cloud). For Edge (OSS), users need to set it to `"Bearer"`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
