### PR TITLE
feat: expose HTTP response headers in InfluxDBApiException

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,9 @@
 ## 0.8.0 [unreleased]
+
+### Features
+
+1.[#118](https://github.com/InfluxCommunity/influxdb3-csharp/pull/118): Simplify getting response headers and status code from `InfluxDBApiException`.  Includes example runnable through `Examples/General`.
+
 ## 0.7.0 [2024-08-12]
 
 ### Migration Notice

--- a/Client.Test.Integration/IntegrationTest.cs
+++ b/Client.Test.Integration/IntegrationTest.cs
@@ -1,0 +1,43 @@
+
+
+using System;
+using System.Diagnostics;
+using NUnit.Framework;
+
+namespace InfluxDB3.Client.Test.Integration;
+
+public abstract class IntegrationTest
+{
+    private static readonly TraceListener ConsoleOutListener = new TextWriterTraceListener(Console.Out);
+
+    protected string Host { get; private set; } = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_URL") ??
+                                                throw new InvalidOperationException(
+                                                    "TESTING_INFLUXDB_URL environment variable is not set.");
+
+    protected string Token { get; private set; } = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_TOKEN") ??
+                                                   throw new InvalidOperationException(
+                                                       "TESTING_INFLUXDB_TOKEN environment variable is not set.");
+
+    protected string Database { get; private set; } = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_DATABASE") ??
+                                                      throw new InvalidOperationException(
+                                                          "TESTING_INFLUXDB_DATABASE environment variable is not set.");
+
+    [OneTimeSetUp]
+    public void OneTimeSetUp()
+    {
+        if (!Trace.Listeners.Contains(ConsoleOutListener))
+        {
+            Console.SetOut(TestContext.Progress);
+            Trace.Listeners.Add(ConsoleOutListener);
+        }
+    }
+
+    [OneTimeTearDownAttribute]
+    public void OneTimeTearDownAttribute()
+    {
+        ConsoleOutListener.Dispose();
+    }
+    
+    
+
+}

--- a/Client.Test.Integration/IntegrationTest.cs
+++ b/Client.Test.Integration/IntegrationTest.cs
@@ -37,7 +37,4 @@ public abstract class IntegrationTest
     {
         ConsoleOutListener.Dispose();
     }
-    
-    
-
 }

--- a/Client.Test.Integration/QueryWriteTest.cs
+++ b/Client.Test.Integration/QueryWriteTest.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Diagnostics;
 using System.Linq;
 using System.Threading.Tasks;
 using Grpc.Core;
@@ -12,41 +11,17 @@ using WriteOptions = InfluxDB3.Client.Config.WriteOptions;
 
 namespace InfluxDB3.Client.Test.Integration;
 
-public class QueryWriteTest
+public class QueryWriteTest : IntegrationTest
 {
-    private static readonly TraceListener ConsoleOutListener = new TextWriterTraceListener(Console.Out);
-
-    private readonly string _host = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_URL") ??
-                                       throw new InvalidOperationException("TESTING_INFLUXDB_URL environment variable is not set.");
-    private readonly string _token = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_TOKEN") ??
-                                         throw new InvalidOperationException("TESTING_INFLUXDB_TOKEN environment variable is not set.");
-    private readonly string _database = Environment.GetEnvironmentVariable("TESTING_INFLUXDB_DATABASE") ??
-                                        throw new InvalidOperationException("TESTING_INFLUXDB_DATABASE environment variable is not set.");
-
-    [OneTimeSetUp]
-    public void OneTimeSetUp()
-    {
-        if (!Trace.Listeners.Contains(ConsoleOutListener))
-        {
-            Console.SetOut(TestContext.Progress);
-            Trace.Listeners.Add(ConsoleOutListener);
-        }
-    }
-
-    [OneTimeTearDownAttribute]
-    public void OneTimeTearDownAttribute()
-    {
-        ConsoleOutListener.Dispose();
-    }
 
     [Test]
     public async Task QueryWrite()
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Token = _token,
-            Database = _database
+            Host = Host,
+            Token = Token,
+            Database = Database
         });
 
         const string measurement = "integration_test";
@@ -82,8 +57,8 @@ public class QueryWriteTest
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Database = _database
+            Host = Host,
+            Database = Database
         });
 
         var ae = Assert.ThrowsAsync<RpcException>(async () =>
@@ -102,9 +77,9 @@ public class QueryWriteTest
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Database = _database,
-            Token = _token
+            Host = Host,
+            Database = Database,
+            Token = Token
         });
 
         await client.WritePointAsync(PointData.Measurement("cpu").SetTag("tag", "c"));
@@ -115,9 +90,9 @@ public class QueryWriteTest
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Database = _database,
-            Token = _token,
+            Host = Host,
+            Database = Database,
+            Token = Token,
             DisableServerCertificateValidation = true
         });
 
@@ -129,9 +104,9 @@ public class QueryWriteTest
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Database = _database,
-            Token = _token,
+            Host = Host,
+            Database = Database,
+            Token = Token,
             WriteOptions = new WriteOptions
             {
                 GzipThreshold = 1
@@ -146,9 +121,9 @@ public class QueryWriteTest
     {
         using var client = new InfluxDBClient(new ClientConfig
         {
-            Host = _host,
-            Token = _token,
-            Database = _database
+            Host = Host,
+            Token = Token,
+            Database = Database
         });
 
         var testId = DateTime.UtcNow.Millisecond;

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -1,0 +1,61 @@
+using System;
+using System.Collections.Frozen;
+using System.Linq;
+using System.Threading.Tasks;
+using InfluxDB3.Client.Config;
+using NUnit.Framework;
+
+namespace InfluxDB3.Client.Test.Integration;
+
+public class WriteTest : IntegrationTest
+{
+
+    [Test]
+    public async Task WriteWithError()
+    {
+        using var client = new InfluxDBClient(new ClientConfig
+        {
+            Host = Host,
+            Token = Token,
+            Database = Database,
+        });
+        
+        try
+        {
+            await client.WriteRecordAsync("vehicle,id=vwbus vel=0.0,distance=,status=\"STOPPED\"");
+        }
+        catch (Exception ex)
+        {
+            if (ex is InfluxDBApiException)
+            {
+                var iaex = (InfluxDBApiException)ex;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(iaex.Message,
+                        Is.EqualTo(
+                            "errors encountered on line(s): line 1: " +
+                            "Could not parse entire line. Found trailing content: 'distance=,status=\"STOPPED\"'"
+                        ));
+                    Assert.That(iaex.GetStatusCode().ToString(), Is.EqualTo("BadRequest"));
+                    Assert.That(iaex.GetStatusCode().GetHashCode(), Is.EqualTo(400));
+                });
+                var headersDix = iaex.GetHeaders().ToFrozenDictionary();
+                Assert.DoesNotThrow(() =>
+                {
+                    Assert.Multiple(() =>
+                    {
+                        Assert.That(headersDix["trace-id"].First(), Is.Not.Empty);
+                        Assert.That(headersDix["trace-sampled"].First(), Is.EqualTo("false"));
+                        Assert.That(headersDix["Strict-Transport-Security"].First(), Is.Not.Empty);
+                        Assert.That(headersDix["X-Influxdb-Request-ID"].First(), Is.Not.Empty);
+                        Assert.That(headersDix["X-Influxdb-Build"].First(), Is.EqualTo("Cloud"));
+                    });
+                });
+            }
+            else
+            {
+                Assert.Fail($"Should catch InfluxDBApiException, but received {ex.GetType()}: {ex.Message}.");
+            }
+        }
+    }
+}

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -36,10 +36,10 @@ public class WriteTest : IntegrationTest
                             "errors encountered on line(s): line 1: " +
                             "Could not parse entire line. Found trailing content: 'distance=,status=\"STOPPED\"'"
                         ));
-                    Assert.That(iaex.GetStatusCode().ToString(), Is.EqualTo("BadRequest"));
-                    Assert.That(iaex.GetStatusCode().GetHashCode(), Is.EqualTo(400));
+                    Assert.That(iaex.StatusCode.ToString(), Is.EqualTo("BadRequest"));
+                    Assert.That(iaex.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.BadRequest));
                 });
-                var headersDix = iaex.GetHeaders().ToFrozenDictionary();
+                var headersDix = iaex.Headers.ToFrozenDictionary();
                 Assert.DoesNotThrow(() =>
                 {
                     Assert.Multiple(() =>

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -32,10 +32,7 @@ public class WriteTest : IntegrationTest
                 Assert.Multiple(() =>
                 {
                     Assert.That(iaex.Message,
-                        Is.EqualTo(
-                            "errors encountered on line(s): line 1: " +
-                            "Could not parse entire line. Found trailing content: 'distance=,status=\"STOPPED\"'"
-                        ));
+                        Contains.Substring("Found trailing content: 'distance=,status=\"STOPPED\"'"));
                     Assert.That(iaex.StatusCode.ToString(), Is.EqualTo("BadRequest"));
                     Assert.That(iaex.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.BadRequest));
                 });

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -19,7 +19,7 @@ public class WriteTest : IntegrationTest
             Token = Token,
             Database = Database,
         });
-        
+
         try
         {
             await client.WriteRecordAsync("vehicle,id=vwbus vel=0.0,distance=,status=\"STOPPED\"");

--- a/Client.Test/InfluxDBApiExceptionTest.cs
+++ b/Client.Test/InfluxDBApiExceptionTest.cs
@@ -1,0 +1,77 @@
+using System;
+using System.Collections.Frozen;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using WireMock.RequestBuilders;
+using WireMock.ResponseBuilders;
+
+namespace InfluxDB3.Client.Test;
+
+public class InfluxDBApiExceptionTest : MockServerTest
+{
+    
+    private InfluxDBClient _client;
+    
+    [TearDown]
+    public void TearDown()
+    {
+        base.TearDown();
+        _client.Dispose();
+    }
+
+    [Test]
+    public async Task GeneratedInfluxDbException()
+    {
+        var requestId = Guid.NewGuid().ToString();
+        
+        MockServer
+            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .RespondWith(Response.Create()
+                .WithStatusCode(400)
+                .WithBody("{ \"message\": \"just testing\", \"statusCode\": \"bad request\" }")
+                .WithHeaders(new Dictionary<string, string>()
+                {
+                    {"Content-Type", "application/json"},
+                    {"Trace-Id", "123456789ABCDEF0"},
+                    {"Trace-Sampled", "false"},
+                    {"X-Influxdb-Request-ID", requestId},
+                    {"X-Influxdb-Build", "Cloud"}
+                })
+            );
+        
+        _client = new InfluxDBClient(MockServerUrl, 
+            "my-token", 
+            "my-org", 
+            "my-database");
+        try
+        {
+            await _client.WriteRecordAsync("wetbulb,location=prg val=20.1");
+        }
+        catch (Exception ex)
+        {
+            if (ex is InfluxDBApiException)
+            {
+                var idbae = (InfluxDBApiException)ex;
+                Assert.Multiple(() =>
+                {
+                    Assert.That(idbae.Message, Is.EqualTo("just testing"));
+                    Assert.That(idbae.GetStatusCode().ToString(), Is.EqualTo("BadRequest"));
+                    Assert.That(idbae.GetHeaders().Count() == 7);
+                });
+                var headersDix = idbae.GetHeaders().ToFrozenDictionary();
+                Assert.Multiple(() =>
+                {
+                    Assert.That(headersDix["Trace-Id"].First(), Is.EqualTo("123456789ABCDEF0"));
+                    Assert.That(headersDix["Trace-Sampled"].First(), Is.EqualTo("false"));
+                    Assert.That(headersDix["X-Influxdb-Request-ID"].First(), Is.EqualTo(requestId));
+                    Assert.That(headersDix["X-Influxdb-Build"].First(), Is.EqualTo("Cloud"));
+                });
+            }
+            else
+            {
+                Assert.Fail($"Should have thrown InfluxdbApiException. Not - {ex}");
+            }
+        }
+    }
+}

--- a/Client.Test/InfluxDBApiExceptionTest.cs
+++ b/Client.Test/InfluxDBApiExceptionTest.cs
@@ -17,7 +17,16 @@ public class InfluxDBApiExceptionTest : MockServerTest
     public void TearDown()
     {
         base.TearDown();
-        _client.Dispose();
+        _client?.Dispose();
+    }
+
+    [Test]
+    public void NullValuesTest()
+    {
+        var exception = new InfluxDBApiException("Testing exception", null);
+        Assert.That(exception.GetStatusCode().ToString(), Is.EqualTo("0"));
+        var headers = exception.GetHeaders();
+        Assert.That(exception.GetHeaders(), Is.Null);
     }
 
     [Test]

--- a/Client.Test/InfluxDBApiExceptionTest.cs
+++ b/Client.Test/InfluxDBApiExceptionTest.cs
@@ -10,9 +10,9 @@ namespace InfluxDB3.Client.Test;
 
 public class InfluxDBApiExceptionTest : MockServerTest
 {
-    
+
     private InfluxDBClient _client;
-    
+
     [TearDown]
     public void TearDown()
     {
@@ -24,7 +24,7 @@ public class InfluxDBApiExceptionTest : MockServerTest
     public async Task GeneratedInfluxDbException()
     {
         var requestId = Guid.NewGuid().ToString();
-        
+
         MockServer
             .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
             .RespondWith(Response.Create()
@@ -39,10 +39,10 @@ public class InfluxDBApiExceptionTest : MockServerTest
                     {"X-Influxdb-Build", "Cloud"}
                 })
             );
-        
-        _client = new InfluxDBClient(MockServerUrl, 
-            "my-token", 
-            "my-org", 
+
+        _client = new InfluxDBClient(MockServerUrl,
+            "my-token",
+            "my-org",
             "my-database");
         try
         {

--- a/Client.Test/InfluxDBApiExceptionTest.cs
+++ b/Client.Test/InfluxDBApiExceptionTest.cs
@@ -24,9 +24,9 @@ public class InfluxDBApiExceptionTest : MockServerTest
     public void NullValuesTest()
     {
         var exception = new InfluxDBApiException("Testing exception", null);
-        Assert.That(exception.GetStatusCode().ToString(), Is.EqualTo("0"));
-        var headers = exception.GetHeaders();
-        Assert.That(exception.GetHeaders(), Is.Null);
+        Assert.That(exception.StatusCode.ToString(), Is.EqualTo("0"));
+        var headers = exception.Headers;
+        Assert.That(exception.Headers, Is.Null);
     }
 
     [Test]
@@ -65,10 +65,10 @@ public class InfluxDBApiExceptionTest : MockServerTest
                 Assert.Multiple(() =>
                 {
                     Assert.That(idbae.Message, Is.EqualTo("just testing"));
-                    Assert.That(idbae.GetStatusCode().ToString(), Is.EqualTo("BadRequest"));
-                    Assert.That(idbae.GetHeaders().Count() == 7);
+                    Assert.That(idbae.StatusCode.ToString(), Is.EqualTo("BadRequest"));
+                    Assert.That(idbae.Headers.Count() == 7);
                 });
-                var headersDix = idbae.GetHeaders().ToFrozenDictionary();
+                var headersDix = idbae.Headers.ToFrozenDictionary();
                 Assert.Multiple(() =>
                 {
                     Assert.That(headersDix["Trace-Id"].First(), Is.EqualTo("123456789ABCDEF0"));

--- a/Client/InfluxDBApiException.cs
+++ b/Client/InfluxDBApiException.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Net;
 using System.Net.Http;
+using System.Net.Http.Headers;
 
 namespace InfluxDB3.Client;
 
@@ -14,4 +16,15 @@ public class InfluxDBApiException : Exception
     }
 
     public HttpResponseMessage? HttpResponseMessage { get; private set; }
+
+    public HttpResponseHeaders GetHeaders()
+    {
+        return HttpResponseMessage?.Headers;
+    }
+
+    public HttpStatusCode GetStatusCode()
+    {
+        return HttpResponseMessage?.StatusCode ?? 0;
+    }
+
 }

--- a/Client/InfluxDBApiException.cs
+++ b/Client/InfluxDBApiException.cs
@@ -17,14 +17,20 @@ public class InfluxDBApiException : Exception
 
     public HttpResponseMessage? HttpResponseMessage { get; private set; }
 
-    public HttpResponseHeaders GetHeaders()
+    public HttpResponseHeaders? Headers
     {
-        return HttpResponseMessage?.Headers;
+        get
+        {
+            return HttpResponseMessage?.Headers;
+        }
     }
 
-    public HttpStatusCode GetStatusCode()
+    public HttpStatusCode StatusCode
     {
-        return HttpResponseMessage?.StatusCode ?? 0;
+        get
+        {
+            return HttpResponseMessage?.StatusCode ?? 0;
+        }
     }
 
 }

--- a/Examples/Downsampling/DownsamplingExample.cs
+++ b/Examples/Downsampling/DownsamplingExample.cs
@@ -9,9 +9,9 @@ public class DownsamplingExample
 {
     static async Task Main(string[] args)
     {
-        const string host = "https://us-east-1-1.aws.cloud2.influxdata.com";
-        const string token = "my-token";
-        const string database = "my-database";
+        var host = Environment.GetEnvironmentVariable("INFLUXDB_URL") ?? "https://us-east-1-1.aws.cloud2.influxdata.com";
+        var token = Environment.GetEnvironmentVariable("INFLUXDB_TOKEN") ?? "my-token";
+        var database = Environment.GetEnvironmentVariable("INFLUXDB_DATABASE") ?? "my-database";
 
         using var client = new InfluxDBClient(host: host, token: token, database: database);
 
@@ -59,5 +59,10 @@ public class DownsamplingExample
 
             await client.WritePointAsync(downsampledPoint);
         }
+    }
+
+    public static async Task Run()
+    {
+        await Main(Array.Empty<string>());
     }
 }

--- a/Examples/General/General.csproj
+++ b/Examples/General/General.csproj
@@ -1,0 +1,20 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+    <PropertyGroup>
+        <OutputType>Exe</OutputType>
+        <TargetFramework>net8.0</TargetFramework>
+        <ImplicitUsings>enable</ImplicitUsings>
+        <Nullable>enable</Nullable>
+        <AssemblyName>InfluxDB3.Examples.General</AssemblyName>
+        <RootNamespace>InfluxDB3.Examples.General</RootNamespace>
+        <StartupObject>InfluxDB3.Examples.General.Runner</StartupObject>
+        <AssemblyOriginatorKeyFile>../../Keys/Key.snk</AssemblyOriginatorKeyFile>
+    </PropertyGroup>
+    
+    <ItemGroup>
+        <ProjectReference Include="..\..\Client\Client.csproj" />
+        <ProjectReference Include="..\Downsampling\Downsampling.csproj" />
+        <ProjectReference Include="..\IOx\Examples.IOx.csproj" />
+    </ItemGroup>
+    
+</Project>

--- a/Examples/General/HttpErrorHandled.cs
+++ b/Examples/General/HttpErrorHandled.cs
@@ -25,8 +25,8 @@ public class HttpErrorHandled
             {
                 InfluxDBApiException apiEx = (InfluxDBApiException)ex;
                 Console.WriteLine("Caught ApiException: {0} \"{1}\"",
-                    apiEx.GetStatusCode(), apiEx.Message);
-                var headers = apiEx.GetHeaders().ToFrozenDictionary();
+                    apiEx.StatusCode, apiEx.Message);
+                var headers = apiEx.Headers.ToFrozenDictionary();
                 Console.WriteLine("Headers:");
                 foreach (var header in headers)
                 {

--- a/Examples/General/HttpErrorHandled.cs
+++ b/Examples/General/HttpErrorHandled.cs
@@ -1,0 +1,42 @@
+using System.Collections.Frozen;
+using InfluxDB3.Client;
+using Console = System.Console;
+
+namespace InfluxDB3.Examples.General;
+
+public class HttpErrorHandled
+{
+    public static async Task Run()
+    {
+        Console.WriteLine("HttpErrorHandled");
+        using var client = new InfluxDBClient(host: Runner.Host, 
+            token: Runner.Token, 
+            database: Runner.Database);
+
+        Console.WriteLine("Writing record");
+
+        try
+        {
+            await client.WriteRecordAsync("vehicle,id=harfa vel=89.7,load=355i,state=");
+        }
+        catch (Exception ex)
+        {
+            if (ex is InfluxDBApiException)
+            {
+                InfluxDBApiException apiEx = (InfluxDBApiException)ex;
+                Console.WriteLine("Caught ApiException: {0} \"{1}\"", 
+                    apiEx.GetStatusCode(), apiEx.Message);
+                var headers = apiEx.GetHeaders().ToFrozenDictionary();
+                Console.WriteLine("Headers:");
+                foreach (var header in headers)
+                {
+                    Console.WriteLine("   {0}: {1}", header.Key, header.Value.First());
+                }
+            }
+            else
+            {
+                throw new Exception($"Unexpected Exception: {ex.Message}", ex);
+            }
+        }
+    }
+}

--- a/Examples/General/HttpErrorHandled.cs
+++ b/Examples/General/HttpErrorHandled.cs
@@ -9,8 +9,8 @@ public class HttpErrorHandled
     public static async Task Run()
     {
         Console.WriteLine("HttpErrorHandled");
-        using var client = new InfluxDBClient(host: Runner.Host, 
-            token: Runner.Token, 
+        using var client = new InfluxDBClient(host: Runner.Host,
+            token: Runner.Token,
             database: Runner.Database);
 
         Console.WriteLine("Writing record");
@@ -24,7 +24,7 @@ public class HttpErrorHandled
             if (ex is InfluxDBApiException)
             {
                 InfluxDBApiException apiEx = (InfluxDBApiException)ex;
-                Console.WriteLine("Caught ApiException: {0} \"{1}\"", 
+                Console.WriteLine("Caught ApiException: {0} \"{1}\"",
                     apiEx.GetStatusCode(), apiEx.Message);
                 var headers = apiEx.GetHeaders().ToFrozenDictionary();
                 Console.WriteLine("Headers:");

--- a/Examples/General/Runner.cs
+++ b/Examples/General/Runner.cs
@@ -6,12 +6,12 @@ namespace InfluxDB3.Examples.General;
 public class Runner
 {
 
-    public static string Host { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_URL") ?? 
+    public static string Host { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_URL") ??
                                                   "http://localhost:8086";
-    public static string Token { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_TOKEN") ?? 
+    public static string Token { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_TOKEN") ??
                                                    "my-token";
 
-    public static string Database { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_DATABASE") ?? 
+    public static string Database { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_DATABASE") ??
                                                       "my-database";
 
     private static readonly Dictionary<string, Func<Task>> Functions = new Dictionary<string, Func<Task>>()
@@ -37,7 +37,7 @@ public class Runner
         if (args.Length != 1)
         {
             Console.WriteLine("InfluxDB Example Runner requires a single argument.");
-            Help(); 
+            Help();
             Environment.Exit(1);
         }
 
@@ -48,7 +48,7 @@ public class Runner
         catch (KeyNotFoundException)
         {
             Console.WriteLine($"Unknown example: {args[0]}");
-            Help(); 
+            Help();
             Environment.Exit(1);
         }
     }

--- a/Examples/General/Runner.cs
+++ b/Examples/General/Runner.cs
@@ -1,0 +1,55 @@
+using InfluxDB3.Examples.Downsampling;
+using InfluxDB3.Examples.IOx;
+
+namespace InfluxDB3.Examples.General;
+
+public class Runner
+{
+
+    public static string Host { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_URL") ?? 
+                                                  "http://localhost:8086";
+    public static string Token { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_TOKEN") ?? 
+                                                   "my-token";
+
+    public static string Database { get; private set; } = Environment.GetEnvironmentVariable("INFLUXDB_DATABASE") ?? 
+                                                      "my-database";
+
+    private static readonly Dictionary<string, Func<Task>> Functions = new Dictionary<string, Func<Task>>()
+    {
+        {"DownSampling", DownsamplingExample.Run},
+        {"HttpErrorHandled", HttpErrorHandled.Run},
+        {"IOx", IOxExample.Run}
+    };
+    private static void Help()
+    {
+        Console.WriteLine("Usage:");
+        Console.WriteLine("  General.exe <ExampleToRun>");
+        Console.WriteLine("    Available examples:");
+        foreach (var key in Functions.Keys)
+        {
+            Console.WriteLine($"      {key}");
+        }
+    }
+
+    public static async Task Main(string[] args)
+    {
+        Console.WriteLine("Starting runner... args {0}", args.Length);
+        if (args.Length != 1)
+        {
+            Console.WriteLine("InfluxDB Example Runner requires a single argument.");
+            Help(); 
+            Environment.Exit(1);
+        }
+
+        try
+        {
+            await Functions[args[0]]();
+        }
+        catch (KeyNotFoundException)
+        {
+            Console.WriteLine($"Unknown example: {args[0]}");
+            Help(); 
+            Environment.Exit(1);
+        }
+    }
+}

--- a/Examples/IOx/IOxExample.cs
+++ b/Examples/IOx/IOxExample.cs
@@ -11,9 +11,9 @@ public class IOxExample
 {
     static async Task Main(string[] args)
     {
-        const string host = "https://us-east-1-1.aws.cloud2.influxdata.com";
-        const string token = "my-token";
-        const string database = "my-database";
+        var host = Environment.GetEnvironmentVariable("INFLUXDB_URL") ?? "https://us-east-1-1.aws.cloud2.influxdata.com";
+        var token = Environment.GetEnvironmentVariable("INFLUXDB_TOKEN") ?? "my-token";
+        var database = Environment.GetEnvironmentVariable("INFLUXDB_DATABASE") ?? "my-database";
 
         using var client = new InfluxDBClient(host: host, token: token, database: database);
 
@@ -104,5 +104,10 @@ public class IOxExample
         {
             Console.WriteLine(row.AsPoint().ToLineProtocol());
         }
+    }
+
+    public static async Task Run()
+    {
+        await Main(Array.Empty<string>());
     }
 }

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -1,4 +1,15 @@
 # Examples
 
+- [General](General/Runner.cs) - for running other examples from the commandline.
+- [HttpErrorHandled](General/HttpErrorHandled.cs) - Accessing HTTP headers when an InfluxDBApiException is thrown.
 - [IOxExample](IOx/IOxExample.cs) - How to use write and query data from InfluxDB IOx
 - [Downsampling](Downsampling/DownsamplingExample.cs) - How to use queries to structure data for downsampling
+
+## General Runner
+
+Examples can be run from the directory `Examples/General` by simply calling `dotnet run`
+
+For example:
+```bash
+Examples/General/$ dotnet run "HttpErrorHandled"
+```

--- a/Examples/README.md
+++ b/Examples/README.md
@@ -10,6 +10,7 @@
 Examples can be run from the directory `Examples/General` by simply calling `dotnet run`
 
 For example:
+
 ```bash
 Examples/General/$ dotnet run "HttpErrorHandled"
 ```

--- a/InfluxDB3.sln
+++ b/InfluxDB3.sln
@@ -15,6 +15,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Examples.IOx", "Examples\IO
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Downsampling", "Examples\Downsampling\Downsampling.csproj", "{44C91C8C-B194-48CE-A5B1-763457F118F4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "General", "Examples\General\General.csproj", "{2355049F-531D-4B43-9DFD-D88C75023B04}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -44,9 +46,14 @@ Global
 		{44C91C8C-B194-48CE-A5B1-763457F118F4}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{44C91C8C-B194-48CE-A5B1-763457F118F4}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{44C91C8C-B194-48CE-A5B1-763457F118F4}.Release|Any CPU.Build.0 = Release|Any CPU
+		{2355049F-531D-4B43-9DFD-D88C75023B04}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{2355049F-531D-4B43-9DFD-D88C75023B04}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{2355049F-531D-4B43-9DFD-D88C75023B04}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{2355049F-531D-4B43-9DFD-D88C75023B04}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(NestedProjects) = preSolution
 		{B2DA69ED-C21D-4531-A32A-E537DC511785} = {EFBEAA10-411F-4BDB-A96B-B54632FAE99D}
 		{44C91C8C-B194-48CE-A5B1-763457F118F4} = {EFBEAA10-411F-4BDB-A96B-B54632FAE99D}
+		{2355049F-531D-4B43-9DFD-D88C75023B04} = {EFBEAA10-411F-4BDB-A96B-B54632FAE99D}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Proposed Changes

- Add methods to `InfluxDBApiException` to get StatusCode and Headers from nested `HttpResponseMessage` more easily. 
- Unit tests of these changes
- Refactor of Integration tests to leverage a base `IntegrationTest` class.
- Integration test of changes to `InfluxDBApiException`
- In Examples adds a `General/Runner.cs` class for unifying running examples. 
- In Examples adds an example for leveraging headers: `HttpErrorHandled.cs`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
