### PR TITLE
feat: respect iox::column_type::field metadata when mapping query

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,15 @@
+## 1.0.0 [unreleased]
+
+### Features
+
+1. [#132](https://github.com/InfluxCommunity/influxdb3-csharp/pull/132): Respect iox::column_type::field metadata when
+   mapping query results into values.
+    - iox::column_type::field::integer: => Long
+    - iox::column_type::field::uinteger: => Long
+    - iox::column_type::field::float: => Double
+    - iox::column_type::field::string: => String
+    - iox::column_type::field::boolean: => Boolean
+
 ## 0.9.0 [unreleased]
 
 ## 0.8.0 [2024-09-13]

--- a/Client.Test/Internal/AssemblyHelperTest.cs
+++ b/Client.Test/Internal/AssemblyHelperTest.cs
@@ -12,7 +12,7 @@ namespace InfluxDB3.Client.Test.Internal
             var version = AssemblyHelper.GetVersion();
             Assert.Multiple(() =>
             {
-                Assert.That(Version.Parse(version).Major, Is.EqualTo(0));
+                Assert.That(Version.Parse(version).Major, Is.EqualTo(1));
                 Assert.That(Version.Parse(version).Minor, Is.GreaterThanOrEqualTo(0));
                 Assert.That(Version.Parse(version).Build, Is.EqualTo(0));
                 Assert.That(Version.Parse(version).Revision, Is.EqualTo(0));

--- a/Client.Test/Internal/RecordBatchConverterTest.cs
+++ b/Client.Test/Internal/RecordBatchConverterTest.cs
@@ -14,26 +14,26 @@ public class RecordBatchConverterTest
         Schema schema;
         RecordBatch recordBatch;
         PointDataValues point;
-        
+
         var stringField = new Field("measurement", StringType.Default, true);
         var stringArray = new StringArray.Builder().Append("host").Build();
         schema = new Schema(new[] { stringField, }, null);
         recordBatch = new RecordBatch(schema, new[] { stringArray }, 1);
         point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
         Assert.That(point.GetMeasurement(), Is.EqualTo("host"));
-        
+
         Assert.Multiple(() =>
         {
             var now = new DateTimeOffset();
-            
+
             var timeField = new Field("time", TimestampType.Default, true);
             var timeArray = new TimestampArray.Builder().Append(now).Build();
             schema = new Schema(new[] { timeField, }, null);
             recordBatch = new RecordBatch(schema, new[] { timeArray }, 1);
-            
+
             point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
             Assert.That(point.GetTimestamp(), Is.EqualTo(TimestampConverter.GetNanoTime(now.UtcDateTime)));
-            
+
             timeField = new Field("test", TimestampType.Default, true);
             schema = new Schema(new[] { timeField, }, null);
             recordBatch = new RecordBatch(schema, new[] { timeArray }, 1);

--- a/Client.Test/Internal/RecordBatchConverterTest.cs
+++ b/Client.Test/Internal/RecordBatchConverterTest.cs
@@ -1,6 +1,8 @@
+using System;
 using Apache.Arrow;
 using Apache.Arrow.Types;
 using InfluxDB3.Client.Internal;
+using InfluxDB3.Client.Write;
 
 namespace InfluxDB3.Client.Test.Internal;
 
@@ -9,11 +11,34 @@ public class RecordBatchConverterTest
     [Test]
     public void ConvertToPointDataValue()
     {
+        Schema schema;
+        RecordBatch recordBatch;
+        PointDataValues point;
+        
         var stringField = new Field("measurement", StringType.Default, true);
         var stringArray = new StringArray.Builder().Append("host").Build();
-        var schema = new Schema(new[] { stringField, }, null);
-        var recordBatch = new RecordBatch(schema, new[] { stringArray }, 1);
-        var point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
+        schema = new Schema(new[] { stringField, }, null);
+        recordBatch = new RecordBatch(schema, new[] { stringArray }, 1);
+        point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
         Assert.That(point.GetMeasurement(), Is.EqualTo("host"));
+        
+        Assert.Multiple(() =>
+        {
+            var now = new DateTimeOffset();
+            
+            var timeField = new Field("time", TimestampType.Default, true);
+            var timeArray = new TimestampArray.Builder().Append(now).Build();
+            schema = new Schema(new[] { timeField, }, null);
+            recordBatch = new RecordBatch(schema, new[] { timeArray }, 1);
+            
+            point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
+            Assert.That(point.GetTimestamp(), Is.EqualTo(TimestampConverter.GetNanoTime(now.UtcDateTime)));
+            
+            timeField = new Field("test", TimestampType.Default, true);
+            schema = new Schema(new[] { timeField, }, null);
+            recordBatch = new RecordBatch(schema, new[] { timeArray }, 1);
+            point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
+            Assert.That(point.GetField("test"), Is.EqualTo(now));
+        });
     }
 }

--- a/Client.Test/Internal/RecordBatchConverterTest.cs
+++ b/Client.Test/Internal/RecordBatchConverterTest.cs
@@ -1,0 +1,19 @@
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using InfluxDB3.Client.Internal;
+
+namespace InfluxDB3.Client.Test.Internal;
+
+public class RecordBatchConverterTest
+{
+    [Test]
+    public void ConvertToPointDataValue()
+    {
+        var stringField = new Field("measurement", StringType.Default, true);
+        var stringArray = new StringArray.Builder().Append("host").Build();
+        var schema = new Schema(new[] { stringField, }, null);
+        var recordBatch = new RecordBatch(schema, new[] { stringArray }, 1);
+        var point = RecordBatchConverter.ConvertToPointDataValue(recordBatch, 0);
+        Assert.That(point.GetMeasurement(), Is.EqualTo("host"));
+    }
+}

--- a/Client.Test/Internal/RestClientTest.cs
+++ b/Client.Test/Internal/RestClientTest.cs
@@ -63,7 +63,7 @@ public class RestClientTest : MockServerTest
 
         var requests = MockServer.LogEntries.ToList();
 
-        Assert.That(requests[0].RequestMessage.Headers?["User-Agent"][0], Does.StartWith("influxdb3-csharp/0."));
+        Assert.That(requests[0].RequestMessage.Headers?["User-Agent"][0], Does.StartWith("influxdb3-csharp/1."));
         Assert.That(requests[0].RequestMessage.Headers?["User-Agent"][0], Does.EndWith(".0.0"));
     }
 

--- a/Client.Test/Internal/TimestampConverterTest.cs
+++ b/Client.Test/Internal/TimestampConverterTest.cs
@@ -1,0 +1,26 @@
+using System;
+using System.Numerics;
+using InfluxDB3.Client.Internal;
+
+namespace InfluxDB3.Client.Test.Internal;
+
+public class TimestampConverterTest
+{
+    private static readonly DateTime EpochStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+
+    [Test]
+    public void GetNanoTime()
+    {
+        var now = DateTime.Now;
+
+        var localTime = DateTime.SpecifyKind(now, DateTimeKind.Local);
+        var timestamp = TimestampConverter.GetNanoTime(localTime);
+        BigInteger nanoTime = now.ToUniversalTime().Subtract(EpochStart).Ticks * 100;
+        Assert.That(nanoTime, Is.EqualTo(timestamp));
+
+        var unspecifiedTime = DateTime.SpecifyKind(now, DateTimeKind.Unspecified);
+        timestamp = TimestampConverter.GetNanoTime(unspecifiedTime);
+        nanoTime = DateTime.SpecifyKind(now, DateTimeKind.Utc).Subtract(EpochStart).Ticks * 100;
+        Assert.That(nanoTime, Is.EqualTo(timestamp));
+    }
+}

--- a/Client.Test/Internal/TypeCastTest.cs
+++ b/Client.Test/Internal/TypeCastTest.cs
@@ -68,8 +68,8 @@ public class TypeCastTest
             Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
             Assert.That(TypeCasting.GetMappedValue(field, 10)!, Is.EqualTo(10));
         });
-        
-        
+
+
         field = GenerateIntFieldTestTypeMeta(fieldName);
         Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
     }
@@ -84,7 +84,7 @@ public class TypeCastTest
         };
         return new Field(fieldName, Int64Type.Default, true, meta);
     }
-    
+
     private static Field GenerateIntField(string fieldName)
     {
         var meta = new Dictionary<string, string>

--- a/Client.Test/Internal/TypeCastTest.cs
+++ b/Client.Test/Internal/TypeCastTest.cs
@@ -70,16 +70,16 @@ public class TypeCastTest
         });
         
         
-        field = GenerateIntFieldNullTypeMeta(fieldName);
+        field = GenerateIntFieldTestTypeMeta(fieldName);
         Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
     }
 
-    private static Field GenerateIntFieldNullTypeMeta(string fieldName)
+    private static Field GenerateIntFieldTestTypeMeta(string fieldName)
     {
         var meta = new Dictionary<string, string>
         {
             {
-                "iox::column::type", null
+                "iox::column::type", "iox::column_type::field::test"
             }
         };
         return new Field(fieldName, Int64Type.Default, true, meta);

--- a/Client.Test/Internal/TypeCastTest.cs
+++ b/Client.Test/Internal/TypeCastTest.cs
@@ -68,6 +68,12 @@ public class TypeCastTest
             Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
             Assert.That(TypeCasting.GetMappedValue(field, 10)!, Is.EqualTo(10));
         });
+        
+        // Field without metadata case
+        field = new Field(fieldName, Int64Type.Default, true);
+        Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
+        
+        // Assert.That(TypeCasting.GetMappedValue(field, )!, Is.EqualTo("a"));
     }
 
     private static Field GenerateIntField(string fieldName)

--- a/Client.Test/Internal/TypeCastTest.cs
+++ b/Client.Test/Internal/TypeCastTest.cs
@@ -69,13 +69,22 @@ public class TypeCastTest
             Assert.That(TypeCasting.GetMappedValue(field, 10)!, Is.EqualTo(10));
         });
         
-        // Field without metadata case
-        field = new Field(fieldName, Int64Type.Default, true);
-        Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
         
-        // Assert.That(TypeCasting.GetMappedValue(field, )!, Is.EqualTo("a"));
+        field = GenerateIntFieldNullTypeMeta(fieldName);
+        Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
     }
 
+    private static Field GenerateIntFieldNullTypeMeta(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", null
+            }
+        };
+        return new Field(fieldName, Int64Type.Default, true, meta);
+    }
+    
     private static Field GenerateIntField(string fieldName)
     {
         var meta = new Dictionary<string, string>

--- a/Client.Test/Internal/TypeCastTest.cs
+++ b/Client.Test/Internal/TypeCastTest.cs
@@ -1,0 +1,127 @@
+using System.Collections.Generic;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+using InfluxDB3.Client.Internal;
+
+namespace InfluxDB3.Client.Test.Internal;
+
+public class TypeCastTest
+{
+    [Test]
+    public void IsNumber()
+    {
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.IsNumber(1), Is.True);
+            Assert.That(TypeCasting.IsNumber(1.2), Is.True);
+            Assert.That(TypeCasting.IsNumber(-1.2), Is.True);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.IsNumber('1'), Is.False);
+            Assert.That(TypeCasting.IsNumber('a'), Is.False);
+            Assert.That(TypeCasting.IsNumber(true), Is.False);
+            Assert.That(TypeCasting.IsNumber(null), Is.False);
+        });
+    }
+
+    [Test]
+    public void GetMappedValue()
+    {
+        // If pass the correct value type to GetMappedValue() it will return the value with a correct type
+        // If pass the incorrect value type to GetMappedValue() it will NOT throws any error but return the passed value
+        const string fieldName = "test";
+
+        var field = GenerateIntField(fieldName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
+            Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
+        });
+
+        field = GenerateUIntField(fieldName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.GetMappedValue(field, 1)!, Is.EqualTo(1));
+            Assert.That(TypeCasting.GetMappedValue(field, -1)!, Is.EqualTo(-1));
+            Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
+        });
+
+        field = GenerateDoubleField(fieldName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.GetMappedValue(field, 1.2)!, Is.EqualTo(1.2));
+            Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
+        });
+
+        field = GenerateBooleanField(fieldName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.GetMappedValue(field, true)!, Is.EqualTo(true));
+            Assert.That(TypeCasting.GetMappedValue(field, 10)!, Is.EqualTo(10));
+        });
+
+        field = GenerateStringField(fieldName);
+        Assert.Multiple(() =>
+        {
+            Assert.That(TypeCasting.GetMappedValue(field, "a")!, Is.EqualTo("a"));
+            Assert.That(TypeCasting.GetMappedValue(field, 10)!, Is.EqualTo(10));
+        });
+    }
+
+    private static Field GenerateIntField(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", "iox::column_type::field::integer"
+            }
+        };
+        return new Field(fieldName, Int64Type.Default, true, meta);
+    }
+
+    private static Field GenerateUIntField(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", "iox::column_type::field::uinteger"
+            }
+        };
+        return new Field(fieldName, UInt64Type.Default, true, meta);
+    }
+
+    private static Field GenerateDoubleField(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", "iox::column_type::field::float"
+            }
+        };
+        return new Field(fieldName, DoubleType.Default, true, meta);
+    }
+
+    private static Field GenerateBooleanField(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", "iox::column_type::field::boolean"
+            }
+        };
+        return new Field(fieldName, BooleanType.Default, true, meta);
+    }
+
+    private static Field GenerateStringField(string fieldName)
+    {
+        var meta = new Dictionary<string, string>
+        {
+            {
+                "iox::column::type", "iox::column_type::field::string"
+            }
+        };
+        return new Field(fieldName, StringType.Default, true, meta);
+    }
+}

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -12,7 +12,7 @@
         </Description>
         <Authors>InfluxDB3.Client Contributors</Authors>
         <AssemblyName>InfluxDB3.Client</AssemblyName>
-        <VersionPrefix>0.9.0</VersionPrefix>
+        <VersionPrefix>1.0.0</VersionPrefix>
         <VersionSuffix>dev</VersionSuffix>
 
         <PackageId>InfluxDB3.Client</PackageId>

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -543,7 +543,7 @@ namespace InfluxDB3.Client
                             continue;
                         if (objectValue is StringType arrowString)
                             objectValue = arrowString.ToString();
-                        
+
                         if (fullName is "measurement" or "iox::measurement" &&
                             objectValue is string value)
                         {

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -466,16 +466,9 @@ namespace InfluxDB3.Client
                     for (var j = 0; j < columnCount; j++)
                     {
                         if (batch.Column(j) is not ArrowArray array) continue;
-                        var value = array.GetObjectValue(i);
-                        if (value is null)
-                        {
-                            row[j] = null;
-                            continue;
-                        }
-
                         row[j] = TypeCasting.GetMappedValue(
                             batch.Schema.FieldsList[j],
-                            value
+                            array.GetObjectValue(i)
                         );
                     }
 
@@ -546,9 +539,6 @@ namespace InfluxDB3.Client
                             continue;
 
                         var objectValue = array.GetObjectValue(i);
-                        if (objectValue is null)
-                            continue;
-
                         if (fullName is "measurement" or "iox::measurement" &&
                             objectValue is string value)
                         {

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -541,8 +541,6 @@ namespace InfluxDB3.Client
                         var objectValue = array.GetObjectValue(i);
                         if (objectValue is null)
                             continue;
-                        if (objectValue is StringType arrowString)
-                            objectValue = arrowString.ToString();
 
                         if (fullName is "measurement" or "iox::measurement" &&
                             objectValue is string value)

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -464,7 +464,10 @@ namespace InfluxDB3.Client
                     var row = new object?[columnCount];
                     for (var j = 0; j < columnCount; j++)
                     {
-                        if (batch.Column(j) is not ArrowArray array) continue;
+                        if (batch.Column(j) is not ArrowArray array)
+                        {
+                            continue;
+                        }
                         row[j] = TypeCasting.GetMappedValue(
                             batch.Schema.FieldsList[j],
                             array.GetObjectValue(i)

--- a/Client/Internal/RecordBatchConverter.cs
+++ b/Client/Internal/RecordBatchConverter.cs
@@ -26,7 +26,7 @@ internal static class RecordBatchConverter
             {
                 continue;
             }
-            
+
             var objectValue = array.GetObjectValue(rowNumber);
             if (fullName is "measurement" or "iox::measurement" &&
                 objectValue is string value)
@@ -41,9 +41,12 @@ internal static class RecordBatchConverter
                 {
                     point = point.SetTimestamp(timestamp);
                 }
-                else
+                else if (objectValue != null)
+                {
                     // just push as field If you don't know what type is it
                     point = point.SetField(fullName, objectValue);
+                }
+
 
                 continue;
             }
@@ -53,15 +56,15 @@ internal static class RecordBatchConverter
             var valueType = parts[2];
             // string fieldType = parts.Length > 3 ? parts[3] : "";
             var mappedValue = TypeCasting.GetMappedValue(schema, objectValue);
-            if (valueType == "field")
+            if (valueType == "field" && mappedValue != null)
             {
                 point = point.SetField(fullName, mappedValue);
             }
-            else if (valueType == "tag")
+            else if (valueType == "tag" && mappedValue != null)
             {
                 point = point.SetTag(fullName, (string)mappedValue);
             }
-            else if (valueType == "timestamp")
+            else if (valueType == "timestamp" && mappedValue != null)
             {
                 point = point.SetTimestamp((BigInteger)mappedValue);
             }

--- a/Client/Internal/RecordBatchConverter.cs
+++ b/Client/Internal/RecordBatchConverter.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Numerics;
+using Apache.Arrow;
+using InfluxDB3.Client.Write;
+using ArrowArray = Apache.Arrow.Array;
+
+namespace InfluxDB3.Client.Internal;
+
+public static class RecordBatchConverter
+{
+    /// <summary>
+    /// Convert a given row of data from RecordBatch to PointDataValues
+    /// </summary>
+    /// <param name="recordBatch">The RecordBatch to get data from</param>
+    /// <param name="rowNumber">The row number</param>
+    /// <returns>The PointDataValues</returns>
+    public static PointDataValues ConvertToPointDataValue(RecordBatch recordBatch, int rowNumber)
+    {
+        PointDataValues point = new();
+        for (var columnIndex = 0; columnIndex < recordBatch.ColumnCount; columnIndex++)
+        {
+            var schema = recordBatch.Schema.FieldsList[columnIndex];
+            var fullName = schema.Name;
+
+            if (recordBatch.Column(columnIndex) is not ArrowArray array)
+                continue;
+
+            var objectValue = array.GetObjectValue(rowNumber);
+            if (fullName is "measurement" or "iox::measurement" &&
+                objectValue is string value)
+            {
+                point = point.SetMeasurement(value);
+                continue;
+            }
+
+            if (!schema.HasMetadata)
+            {
+                if (fullName == "time" && objectValue is DateTimeOffset timestamp)
+                {
+                    point = point.SetTimestamp(timestamp);
+                }
+                else
+                    // just push as field If you don't know what type is it
+                    point = point.SetField(fullName, objectValue);
+
+                continue;
+            }
+
+            var type = schema.Metadata["iox::column::type"];
+            var parts = type.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+            var valueType = parts[2];
+            // string fieldType = parts.Length > 3 ? parts[3] : "";
+            var mappedValue = TypeCasting.GetMappedValue(schema, objectValue);
+            if (valueType == "field")
+            {
+                point = point.SetField(fullName, mappedValue);
+            }
+            else if (valueType == "tag")
+            {
+                point = point.SetTag(fullName, (string)mappedValue);
+            }
+            else if (valueType == "timestamp")
+            {
+                point = point.SetTimestamp((BigInteger)mappedValue);
+            }
+        }
+
+        return point;
+    }
+}

--- a/Client/Internal/RecordBatchConverter.cs
+++ b/Client/Internal/RecordBatchConverter.cs
@@ -6,7 +6,7 @@ using ArrowArray = Apache.Arrow.Array;
 
 namespace InfluxDB3.Client.Internal;
 
-public static class RecordBatchConverter
+internal static class RecordBatchConverter
 {
     /// <summary>
     /// Convert a given row of data from RecordBatch to PointDataValues
@@ -14,7 +14,7 @@ public static class RecordBatchConverter
     /// <param name="recordBatch">The RecordBatch to get data from</param>
     /// <param name="rowNumber">The row number</param>
     /// <returns>The PointDataValues</returns>
-    public static PointDataValues ConvertToPointDataValue(RecordBatch recordBatch, int rowNumber)
+    internal static PointDataValues ConvertToPointDataValue(RecordBatch recordBatch, int rowNumber)
     {
         PointDataValues point = new();
         for (var columnIndex = 0; columnIndex < recordBatch.ColumnCount; columnIndex++)
@@ -23,8 +23,10 @@ public static class RecordBatchConverter
             var fullName = schema.Name;
 
             if (recordBatch.Column(columnIndex) is not ArrowArray array)
+            {
                 continue;
-
+            }
+            
             var objectValue = array.GetObjectValue(rowNumber);
             if (fullName is "measurement" or "iox::measurement" &&
                 objectValue is string value)

--- a/Client/Internal/TimestampConverter.cs
+++ b/Client/Internal/TimestampConverter.cs
@@ -6,7 +6,7 @@ namespace InfluxDB3.Client.Internal;
 public class TimestampConverter
 {
     private static readonly DateTime EpochStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
-    
+
     /// <summary>
     /// Get nano time from Datetime and EpochStart time .
     /// </summary>
@@ -19,7 +19,7 @@ public class TimestampConverter
             DateTimeKind.Local => dateTime.ToUniversalTime(),
             DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc),
             _ => dateTime
-        };    
+        };
         return utcTimestamp.Subtract(EpochStart).Ticks * 100;
-    } 
+    }
 }

--- a/Client/Internal/TimestampConverter.cs
+++ b/Client/Internal/TimestampConverter.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace InfluxDB3.Client.Internal;
 
-public static class TimestampConverter
+internal static class TimestampConverter
 {
     private static readonly DateTime EpochStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 
@@ -12,7 +12,7 @@ public static class TimestampConverter
     /// </summary>
     /// <param name="dateTime">the Datetime object</param>
     /// <returns>the time in nanosecond</returns>
-    public static BigInteger GetNanoTime(DateTime dateTime)
+    internal static BigInteger GetNanoTime(DateTime dateTime)
     {
         var utcTimestamp = dateTime.Kind switch
         {

--- a/Client/Internal/TimestampConverter.cs
+++ b/Client/Internal/TimestampConverter.cs
@@ -3,7 +3,7 @@ using System.Numerics;
 
 namespace InfluxDB3.Client.Internal;
 
-public class TimestampConverter
+public static class TimestampConverter
 {
     private static readonly DateTime EpochStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
 

--- a/Client/Internal/TimestampConverter.cs
+++ b/Client/Internal/TimestampConverter.cs
@@ -10,7 +10,7 @@ public static class TimestampConverter
     /// <summary>
     /// Get nano time from Datetime and EpochStart time .
     /// </summary>
-    /// <param name="timestamp">the Datetime object</param>
+    /// <param name="dateTime">the Datetime object</param>
     /// <returns>the time in nanosecond</returns>
     public static BigInteger GetNanoTime(DateTime dateTime)
     {

--- a/Client/Internal/TimestampConverter.cs
+++ b/Client/Internal/TimestampConverter.cs
@@ -1,0 +1,25 @@
+using System;
+using System.Numerics;
+
+namespace InfluxDB3.Client.Internal;
+
+public class TimestampConverter
+{
+    private static readonly DateTime EpochStart = new(1970, 1, 1, 0, 0, 0, DateTimeKind.Utc);
+    
+    /// <summary>
+    /// Get nano time from Datetime and EpochStart time .
+    /// </summary>
+    /// <param name="timestamp">the Datetime object</param>
+    /// <returns>the time in nanosecond</returns>
+    public static BigInteger GetNanoTime(DateTime dateTime)
+    {
+        var utcTimestamp = dateTime.Kind switch
+        {
+            DateTimeKind.Local => dateTime.ToUniversalTime(),
+            DateTimeKind.Unspecified => DateTime.SpecifyKind(dateTime, DateTimeKind.Utc),
+            _ => dateTime
+        };    
+        return utcTimestamp.Subtract(EpochStart).Ticks * 100;
+    } 
+}

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -74,11 +74,6 @@ public class TypeCasting
                         return value;
                     }
 
-                    if (value is StringType v)
-                    {
-                        return v.ToString();
-                    }
-
                     Trace.TraceWarning($"Value [{value}] is not a string");
                     return value;
                 case "iox::column_type::field::boolean":

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Diagnostics;
+using System.Numerics;
+using Apache.Arrow;
+using Apache.Arrow.Types;
+
+namespace InfluxDB3.Client.Internal;
+
+public class TypeCasting
+{
+    /// <summary>
+    /// Function to cast value return based on metadata from InfluxDB.
+    /// </summary>
+    /// <param name="field">The Field object from Arrow</param>
+    /// <param name="value">The value to cast</param>
+    /// <returns>The value with the correct type</returns>
+    public static object? GetMappedValue(Field field, object? value)
+    {
+        if (value is null)
+        {
+            return null;
+        }
+
+        var fieldName = field.Name;
+        if (fieldName is "measurement" or "iox::measurement")
+        {
+            return Convert.ToString(value);
+        }
+
+        var metaType = field.HasMetadata ? field.Metadata["iox::column::type"] : null;
+        if (metaType == null)
+        {
+            if (fieldName == "time" && value is DateTimeOffset timeOffset)
+            {
+                return TimestampConverter.GetNanoTime(timeOffset.UtcDateTime);
+            }
+
+            return value;
+        }
+
+        var parts = metaType.Split(new[] { ':' }, StringSplitOptions.RemoveEmptyEntries);
+        var valueType = parts[2];
+        if (valueType == "field")
+        {
+            switch (metaType)
+            {
+                case "iox::column_type::field::integer":
+                    if (IsNumber(value))
+                    {
+                        return Convert.ToInt64(value);
+                    }
+
+                    Trace.TraceWarning($"Value [{value}] is not a long");
+                    return value;
+                case "iox::column_type::field::uinteger":
+                    if (IsNumber(value) && Convert.ToInt64(value) >= 0)
+                    {
+                        return Convert.ToUInt64(value);
+                    }
+
+                    Trace.TraceWarning($"Value [{value}] is not an unsigned long");
+                    return value;
+                case "iox::column_type::field::float":
+                    if (IsNumber(value))
+                    {
+                        return Convert.ToDouble(value);
+                    }
+
+                    Trace.TraceWarning($"Value [{value}] is not a double");
+                    return value;
+                case "iox::column_type::field::string":
+                    if (value is string)
+                    {
+                        return value;
+                    }
+
+                    if (value is StringType v)
+                    {
+                        return v.ToString();
+                    }
+
+                    Trace.TraceWarning($"Value [{value}] is not a string");
+                    return value;
+                case "iox::column_type::field::boolean":
+                    if (value is bool)
+                    {
+                        return Convert.ToBoolean(value);
+                    }
+
+                    Trace.TraceWarning($"Value [{value}] is not a boolean");
+                    return value;
+                default:
+                    return value;
+            }
+        }
+
+        if (valueType == "timestamp" && value is DateTimeOffset dateTimeOffset)
+        {
+            return TimestampConverter.GetNanoTime(dateTimeOffset.UtcDateTime);
+        }
+
+        return value;
+    }
+
+    public static bool IsNumber(object? value)
+    {
+        return value is sbyte
+            or byte
+            or short
+            or ushort
+            or int
+            or uint
+            or long
+            or ulong
+            or float
+            or double
+            or decimal
+            or BigInteger;
+    }
+}

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -19,11 +19,6 @@ public class TypeCasting
             return null;
         
         var fieldName = field.Name;
-        if (fieldName is "measurement" or "iox::measurement")
-        {
-            return Convert.ToString(value);
-        }
-
         var metaType = field.HasMetadata ? field.Metadata["iox::column::type"] : null;
         if (metaType == null)
         {

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -2,7 +2,6 @@ using System;
 using System.Diagnostics;
 using System.Numerics;
 using Apache.Arrow;
-using Apache.Arrow.Types;
 
 namespace InfluxDB3.Client.Internal;
 
@@ -14,13 +13,8 @@ public class TypeCasting
     /// <param name="field">The Field object from Arrow</param>
     /// <param name="value">The value to cast</param>
     /// <returns>The value with the correct type</returns>
-    public static object? GetMappedValue(Field field, object? value)
+    public static object GetMappedValue(Field field, object value)
     {
-        if (value is null)
-        {
-            return null;
-        }
-
         var fieldName = field.Name;
         if (fieldName is "measurement" or "iox::measurement")
         {

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -13,8 +13,11 @@ public class TypeCasting
     /// <param name="field">The Field object from Arrow</param>
     /// <param name="value">The value to cast</param>
     /// <returns>The value with the correct type</returns>
-    public static object GetMappedValue(Field field, object value)
+    public static object? GetMappedValue(Field field, object? value)
     {
+        if (value == null)
+            return null;
+        
         var fieldName = field.Name;
         if (fieldName is "measurement" or "iox::measurement")
         {

--- a/Client/Internal/TypeCasting.cs
+++ b/Client/Internal/TypeCasting.cs
@@ -17,7 +17,7 @@ public class TypeCasting
     {
         if (value == null)
             return null;
-        
+
         var fieldName = field.Name;
         var metaType = field.HasMetadata ? field.Metadata["iox::column::type"] : null;
         if (metaType == null)

--- a/Client/Write/PointDataValues.cs
+++ b/Client/Write/PointDataValues.cs
@@ -78,6 +78,17 @@ namespace InfluxDB3.Client.Write
         }
 
         /// <summary>
+        /// Updates the timestamp for the point.
+        /// </summary>
+        /// <param name="timestamp">the timestamp in nanosecond</param>
+        /// <returns></returns>
+        public PointDataValues SetTimestamp(BigInteger timestamp)
+        {
+            _time = timestamp;
+            return this;
+        }
+        
+        /// <summary>
         /// Updates the timestamp for the point represented by <see cref="TimeSpan"/>.
         /// </summary>
         /// <param name="timestamp">the timestamp</param>

--- a/Client/Write/PointDataValues.cs
+++ b/Client/Write/PointDataValues.cs
@@ -87,7 +87,7 @@ namespace InfluxDB3.Client.Write
             _time = timestamp;
             return this;
         }
-        
+
         /// <summary>
         /// Updates the timestamp for the point represented by <see cref="TimeSpan"/>.
         /// </summary>


### PR DESCRIPTION
Closes #

## Proposed Changes

Response from the query will now respect the iox::column_type::field metadata

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
