### PR TITLE
feat: support grpc options

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## 1.2.0 [unreleased]
 
+### Features
+
+1. [#155](https://github.com/InfluxCommunity/influxdb3-csharp/pull/155): Allows setting grpc options.
+
 ## 1.1.0 [2025-03-26]
 
 ### Features

--- a/Client.Test.Integration/QueryWriteTest.cs
+++ b/Client.Test.Integration/QueryWriteTest.cs
@@ -183,6 +183,6 @@ public class QueryWriteTest : IntegrationTest
             {
             }
         });
-        Assert.That(ex.StatusCode, Is.EqualTo(StatusCode.DeadlineExceeded));;;
+        Assert.That(ex.StatusCode, Is.EqualTo(StatusCode.DeadlineExceeded));
     }
 }

--- a/Client.Test.Integration/QueryWriteTest.cs
+++ b/Client.Test.Integration/QueryWriteTest.cs
@@ -139,4 +139,74 @@ public class QueryWriteTest : IntegrationTest
             Assert.That(row[0], Is.EqualTo(1234.0));
         }
     }
+
+    [Test]
+    public async Task MaxReceiveMessageSize()
+    {
+        using var client = new InfluxDBClient(new ClientConfig
+        {
+            Host = Host,
+            Token = Token,
+            Database = Database,
+            QueryOptions = new QueryOptions()
+            {
+                MaxReceiveMessageSize = 100
+            }
+        });
+
+        var ex = Assert.ThrowsAsync<RpcException>(async () =>
+        {
+            await foreach (var _ in client.Query("SELECT value FROM integration_test"))
+            {
+            }
+        });
+        Assert.That(ex?.StatusCode, Is.EqualTo(StatusCode.ResourceExhausted));;
+    }
+
+    [Test]
+    public async Task MaxSendMessageSize()
+    {
+        //todo write test, should I test this
+
+        using var client = new InfluxDBClient(new ClientConfig
+        {
+            Host = Host,
+            Token = Token,
+            Database = Database,
+            QueryOptions = new QueryOptions()
+            {
+                MaxSendMessageSize = 0
+            }
+        });
+
+        await client.WritePointAsync(PointData.Measurement("cpu").SetTag("tag", "c"));
+        // var ex = Assert.ThrowsAsync<RpcException>(async () =>
+        // {
+        //     await client.WritePointAsync(PointData.Measurement("cpu").SetTag("tag", "c"));
+        // });
+        // Assert.That(ex?.StatusCode, Is.EqualTo(StatusCode.ResourceExhausted));;
+    }
+
+    [Test]
+    public async Task GrpcDeadline()
+    {
+        using var client = new InfluxDBClient(new ClientConfig
+        {
+            Host = Host,
+            Token = Token,
+            Database = Database,
+            QueryOptions = new QueryOptions()
+            {
+                Deadline = DateTime.UtcNow.AddMicroseconds(1)
+            }
+        });
+
+        var ex = Assert.ThrowsAsync<RpcException>(async () =>
+        {
+            await foreach (var _ in client.Query("SELECT value FROM stat"))
+            {
+            }
+        });
+        Assert.That(ex.StatusCode, Is.EqualTo(StatusCode.DeadlineExceeded));;;
+    }
 }

--- a/Client.Test.Integration/QueryWriteTest.cs
+++ b/Client.Test.Integration/QueryWriteTest.cs
@@ -160,31 +160,7 @@ public class QueryWriteTest : IntegrationTest
             {
             }
         });
-        Assert.That(ex?.StatusCode, Is.EqualTo(StatusCode.ResourceExhausted));;
-    }
-
-    [Test]
-    public async Task MaxSendMessageSize()
-    {
-        //todo write test, should I test this
-
-        using var client = new InfluxDBClient(new ClientConfig
-        {
-            Host = Host,
-            Token = Token,
-            Database = Database,
-            QueryOptions = new QueryOptions()
-            {
-                MaxSendMessageSize = 0
-            }
-        });
-
-        await client.WritePointAsync(PointData.Measurement("cpu").SetTag("tag", "c"));
-        // var ex = Assert.ThrowsAsync<RpcException>(async () =>
-        // {
-        //     await client.WritePointAsync(PointData.Measurement("cpu").SetTag("tag", "c"));
-        // });
-        // Assert.That(ex?.StatusCode, Is.EqualTo(StatusCode.ResourceExhausted));;
+        Assert.That(ex?.StatusCode, Is.EqualTo(StatusCode.ResourceExhausted));
     }
 
     [Test]

--- a/Client.Test/Config/ClientConfigTest.cs
+++ b/Client.Test/Config/ClientConfigTest.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
+using Grpc.Net.Compression;
 using InfluxDB3.Client.Write;
 
 namespace InfluxDB3.Client.Config.Test;
@@ -230,6 +232,8 @@ public class ClientConfigTest
         {
             Deadline = DateTime.Now.AddMinutes(5),
             MaxReceiveMessageSize = 8_388_608,
+            MaxSendMessageSize = 10000,
+            CompressionProviders = ImmutableArray<ICompressionProvider>.Empty
         };
 
         config.QueryOptions = options;

--- a/Client.Test/Config/ClientConfigTest.cs
+++ b/Client.Test/Config/ClientConfigTest.cs
@@ -230,7 +230,6 @@ public class ClientConfigTest
         {
             Deadline = DateTime.Now.AddMinutes(5),
             MaxReceiveMessageSize = 8_388_608,
-            MaxSendMessageSize = 8_388_608
         };
 
         config.QueryOptions = options;

--- a/Client.Test/Config/ClientConfigTest.cs
+++ b/Client.Test/Config/ClientConfigTest.cs
@@ -215,6 +215,29 @@ public class ClientConfigTest
         }
     }
 
+    [Test]
+    public void DefaultQueryOptionsValue()
+    {
+        var config = new ClientConfig();
+        Assert.That(config.QueryOptions, Is.EqualTo(QueryOptions.DefaultOptions));
+    }
+
+    [Test]
+    public void CustomQueryOptions()
+    {
+        var config = new ClientConfig();
+        var options = new QueryOptions
+        {
+            Deadline = DateTime.Now.AddMinutes(5),
+            MaxReceiveMessageSize = 8_388_608,
+            MaxSendMessageSize = 8_388_608
+        };
+
+        config.QueryOptions = options;
+        Assert.That(config.QueryOptions, Is.EqualTo(options));
+    }
+
+
     [TearDown]
     public void Cleanup()
     {

--- a/Client.Test/Config/QueryOptionsTest.cs
+++ b/Client.Test/Config/QueryOptionsTest.cs
@@ -1,0 +1,43 @@
+using System;
+using InfluxDB3.Client.Config;
+
+namespace InfluxDB3.Client.Test.Config;
+
+public class QueryOptionsTest
+{
+    [TestFixture]
+    public class QueryOptionsTests
+    {
+        [Test]
+        public void Clone_CreatesExactCopy()
+        {
+            var options = new QueryOptions
+            {
+                Deadline = DateTime.Now,
+                MaxReceiveMessageSize = 1000
+            };
+
+            var clone = (QueryOptions)options.Clone();
+
+            Assert.That(clone.Deadline, Is.EqualTo(options.Deadline));
+            Assert.That(clone.MaxReceiveMessageSize, Is.EqualTo(options.MaxReceiveMessageSize));
+        }
+
+        [Test]
+        public void Clone_CreatesIndependentCopy()
+        {
+            var options = new QueryOptions
+            {
+                Deadline = DateTime.Now,
+                MaxReceiveMessageSize = 1000
+            };
+
+            var clone = (QueryOptions)options.Clone();
+            options.Deadline = DateTime.Now.AddDays(1);
+            options.MaxReceiveMessageSize = 2000;
+
+            Assert.That(clone.Deadline, Is.Not.EqualTo(options.Deadline));
+            Assert.That(clone.MaxReceiveMessageSize, Is.Not.EqualTo(options.MaxReceiveMessageSize));
+        }
+    }
+}

--- a/Client.Test/Config/QueryOptionsTest.cs
+++ b/Client.Test/Config/QueryOptionsTest.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Immutable;
+using Grpc.Net.Compression;
 using InfluxDB3.Client.Config;
 
 namespace InfluxDB3.Client.Test.Config;
@@ -14,13 +16,17 @@ public class QueryOptionsTest
             var options = new QueryOptions
             {
                 Deadline = DateTime.Now,
-                MaxReceiveMessageSize = 1000
+                MaxReceiveMessageSize = 1000,
+                MaxSendMessageSize = 1000,
+                CompressionProviders = ImmutableArray<ICompressionProvider>.Empty
             };
 
             var clone = (QueryOptions)options.Clone();
 
             Assert.That(clone.Deadline, Is.EqualTo(options.Deadline));
             Assert.That(clone.MaxReceiveMessageSize, Is.EqualTo(options.MaxReceiveMessageSize));
+            Assert.That(clone.MaxSendMessageSize, Is.EqualTo(options.MaxSendMessageSize));
+            Assert.That(clone.CompressionProviders, Is.EqualTo(options.CompressionProviders));
         }
 
         [Test]
@@ -29,15 +35,21 @@ public class QueryOptionsTest
             var options = new QueryOptions
             {
                 Deadline = DateTime.Now,
-                MaxReceiveMessageSize = 1000
+                MaxReceiveMessageSize = 1000,
+                MaxSendMessageSize = 1000,
+                CompressionProviders = ImmutableArray<ICompressionProvider>.Empty
             };
 
             var clone = (QueryOptions)options.Clone();
             options.Deadline = DateTime.Now.AddDays(1);
             options.MaxReceiveMessageSize = 2000;
+            options.MaxSendMessageSize = 2000;
+            options.CompressionProviders = null;
 
             Assert.That(clone.Deadline, Is.Not.EqualTo(options.Deadline));
             Assert.That(clone.MaxReceiveMessageSize, Is.Not.EqualTo(options.MaxReceiveMessageSize));
+            Assert.That(clone.MaxSendMessageSize, Is.Not.EqualTo(options.MaxSendMessageSize));
+            Assert.That(clone.CompressionProviders, Is.Not.EqualTo(options.CompressionProviders));
         }
     }
 }

--- a/Client.Test/Internal/FlightSqlClientTest.cs
+++ b/Client.Test/Internal/FlightSqlClientTest.cs
@@ -1,6 +1,8 @@
 using System;
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Text;
+using Grpc.Net.Compression;
 using InfluxDB3.Client.Config;
 using InfluxDB3.Client.Internal;
 using InfluxDB3.Client.Query;
@@ -180,6 +182,24 @@ public class FlightSqlClientTest : MockServerTest
             Assert.That(prepareHeadersMetadata[0].Key, Is.EqualTo("user-agent"));
             Assert.That(prepareHeadersMetadata[0].Value, Is.EqualTo(AssemblyHelper.GetUserAgent()));
         });
+    }
+
+    [Test]
+    public void TestGrpcCallOptions()
+    {
+        var config = new ClientConfig
+        {
+            Host = MockServerUrl,
+            QueryOptions = {
+                Deadline = DateTime.Now.AddMinutes(5),
+                MaxReceiveMessageSize = 8_388_608,
+                MaxSendMessageSize = 10000,
+                CompressionProviders = ImmutableArray<ICompressionProvider>.Empty
+            }
+        };
+
+        Assert.DoesNotThrow(() =>
+            _flightSqlClient = new FlightSqlClient(config, InfluxDBClient.CreateAndConfigureHttpClient(config)));
     }
 
 }

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -62,6 +62,7 @@ public class ClientConfig
     /// </summary>
     public ClientConfig()
     {
+        QueryOptions = QueryOptions.DefaultOptions;
     }
 
     /// <summary>

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -76,6 +76,7 @@ public class ClientConfig
         AuthScheme = values.Get("authScheme");
         Organization = values.Get("org");
         Database = values.Get("database");
+        QueryOptions = QueryOptions.DefaultOptions;
         ParsePrecision(values.Get("precision"));
         ParseGzipThreshold(values.Get("gzipThreshold"));
     }
@@ -90,6 +91,7 @@ public class ClientConfig
         AuthScheme = env[EnvInfluxAuthScheme] as string;
         Organization = env[EnvInfluxOrg] as string;
         Database = env[EnvInfluxDatabase] as string;
+        QueryOptions = QueryOptions.DefaultOptions;
         ParsePrecision(env[EnvInfluxPrecision] as string);
         ParseGzipThreshold(env[EnvInfluxGzipThreshold] as string);
     }
@@ -177,6 +179,8 @@ public class ClientConfig
     /// Write options.
     /// </summary>
     public WriteOptions? WriteOptions { get; set; }
+
+    public QueryOptions? QueryOptions { get; set; }
 
     internal void Validate()
     {

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -25,6 +25,7 @@ namespace InfluxDB3.Client.Config;
 /// <item>- SslRootsFilePath: SSL root certificates file path.</item>
 /// <item>- Proxy: The HTTP proxy URL. Default is not set.</item>
 /// <item>- WriteOptions: Write options.</item>
+/// <item>- QueryOptions Query options.</item>
 /// </list>
 ///
 /// <para>If you want create client with custom options, you can use the following code:</para>
@@ -40,6 +41,16 @@ namespace InfluxDB3.Client.Config;
 ///    {
 ///        Precision = WritePrecision.S,
 ///        GzipThreshold = 4096
+///    },
+///    QueryOptions = new QueryOptions
+///    {
+///        Deadline = DateTime.UtcNow.AddSeconds(10),
+///        MaxReceiveMessageSize = 4096,
+///        MaxSendMessageSize = 4096,
+///        CompressionProviders = new List&lt;ICompressionProvider&gt;
+///        {
+///            Grpc.Net.Compression.GzipCompressionProvider.Default
+///        }
 ///    }
 /// }); 
 /// </code>
@@ -181,7 +192,7 @@ public class ClientConfig
     /// </summary>
     public WriteOptions? WriteOptions { get; set; }
 
-    public QueryOptions? QueryOptions { get; set; }
+    public QueryOptions QueryOptions { get; set; }
 
     internal void Validate()
     {

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -192,6 +192,9 @@ public class ClientConfig
     /// </summary>
     public WriteOptions? WriteOptions { get; set; }
 
+    /// <summary>
+    /// Configuration options for query behavior in the InfluxDB client.
+    /// </summary>
     public QueryOptions QueryOptions { get; set; }
 
     internal void Validate()

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -4,21 +4,55 @@ using Grpc.Net.Compression;
 
 namespace InfluxDB3.Client.Config;
 
+/// <summary>
+/// Represents the options for configuring query behavior in the client.
+/// </summary>
 public class QueryOptions : ICloneable
 {
+    /// <summary>
+    /// Gets or sets the optional deadline for query execution.
+    /// </summary>
+    /// <remarks>
+    /// This property specifies the maximum time allowed for query execution before a timeout.
+    /// If set to <c>null</c>, no deadline is applied. The value is represented as a nullable <see cref="DateTime"/>.
+    /// </remarks>
     public DateTime? Deadline { get; set; }
 
+    /// <summary>
+    /// Gets or sets the maximum size, in bytes, of a single message that can be received.
+    /// </summary>
+    /// <remarks>
+    /// This property defines an optional limit for the size of incoming messages to avoid excessive memory allocation.
+    /// A value of <c>null</c> specifies that no maximum size is enforced. The default value is 4,194,304 bytes (4 MB).
+    /// </remarks>
     public int? MaxReceiveMessageSize { get; set; }
 
+    /// <summary>
+    /// Gets or sets the maximum size of a message that can be sent.
+    /// </summary>
+    /// <remarks>
+    /// This property defines the maximum allowable size, in bytes, for messages sent by the client.
+    /// If set to <c>null</c>, there is no limit on the size of the sent messages.
+    /// </remarks>
     public int? MaxSendMessageSize { get; set; }
 
+    /// <summary>
+    /// Gets or sets the collection of compression providers used for gRPC message compression.
+    /// </summary>
+    /// <remarks>
+    /// This property specifies the list of compression algorithms available for compressing gRPC messages.
+    /// The value is represented as a nullable list of <see cref="ICompressionProvider"/>.
+    /// If set to <c>null</c>, GrpcProtocolConstants.DefaultCompressionProviders will be used
+    /// </remarks>
     public IList<ICompressionProvider>? CompressionProviders { get; set; }
 
-    public object Clone()
-    {
-        return MemberwiseClone();
-    }
-
+    /// <summary>
+    /// Represents the default query options used throughout the client configuration.
+    /// </summary>
+    /// <remarks>
+    /// This variable is a static, pre-configured instance of <see cref="QueryOptions"/> with default values.
+    /// It specifies parameters such as deadlines, message sizes, and compression for query execution.
+    /// </remarks>
     internal static readonly QueryOptions DefaultOptions = new()
     {
         Deadline = null,
@@ -26,4 +60,15 @@ public class QueryOptions : ICloneable
         MaxSendMessageSize = null,
         CompressionProviders = null
     };
+
+    /// <summary>
+    /// Creates a shallow copy of the current QueryOptions instance.
+    /// </summary>
+    /// <returns>
+    /// A new object that is a shallow copy of the current QueryOptions instance.
+    /// </returns>
+    public object Clone()
+    {
+        return MemberwiseClone();
+    }
 }

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -8,7 +8,6 @@ public class QueryOptions : ICloneable
 
     public int? MaxReceiveMessageSize { get; set; }
 
-    
     public object Clone()
     {
         return MemberwiseClone();

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -8,8 +8,6 @@ public class QueryOptions : ICloneable
 
     public int? MaxReceiveMessageSize { get; set; }
 
-    public int? MaxSendMessageSize { get; set; }
-
     public object Clone()
     {
         return MemberwiseClone();
@@ -18,7 +16,6 @@ public class QueryOptions : ICloneable
     internal static readonly QueryOptions DefaultOptions = new()
     {
         Deadline = null,
-        MaxReceiveMessageSize = 4_194_304,
-        MaxSendMessageSize = null
+        MaxReceiveMessageSize = 4_194_304
     };
 }

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -42,7 +42,7 @@ public class QueryOptions : ICloneable
     /// <remarks>
     /// This property specifies the list of compression algorithms available for compressing gRPC messages.
     /// The value is represented as a nullable list of <see cref="ICompressionProvider"/>.
-    /// If set to <c>null</c>, GrpcProtocolConstants.DefaultCompressionProviders will be used
+    /// If set to <c>null</c>, Gzip will be used
     /// </remarks>
     public IList<ICompressionProvider>? CompressionProviders { get; set; }
 

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -1,0 +1,24 @@
+using System;
+
+namespace InfluxDB3.Client.Config;
+
+public class QueryOptions : ICloneable
+{
+    public DateTime? Deadline { get; set; }
+
+    public int? MaxReceiveMessageSize { get; set; }
+
+    public int? MaxSendMessageSize { get; set; }
+
+    public object Clone()
+    {
+        return MemberwiseClone();
+    }
+
+    internal static readonly QueryOptions DefaultOptions = new()
+    {
+        Deadline = null,
+        MaxReceiveMessageSize = 4_194_304,
+        MaxSendMessageSize = null
+    };
+}

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using Grpc.Net.Compression;
 
 namespace InfluxDB3.Client.Config;
 
@@ -8,6 +10,10 @@ public class QueryOptions : ICloneable
 
     public int? MaxReceiveMessageSize { get; set; }
 
+    public int? MaxSendMessageSize { get; set; }
+
+    public IList<ICompressionProvider>? CompressionProviders { get; set; }
+
     public object Clone()
     {
         return MemberwiseClone();
@@ -16,6 +22,8 @@ public class QueryOptions : ICloneable
     internal static readonly QueryOptions DefaultOptions = new()
     {
         Deadline = null,
-        MaxReceiveMessageSize = 4_194_304
+        MaxReceiveMessageSize = 4_194_304,
+        MaxSendMessageSize = null,
+        CompressionProviders = null
     };
 }

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -8,6 +8,7 @@ public class QueryOptions : ICloneable
 
     public int? MaxReceiveMessageSize { get; set; }
 
+    
     public object Clone()
     {
         return MemberwiseClone();

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -61,8 +61,7 @@ internal class FlightSqlClient : IFlightSqlClient
                 Credentials = _config.Host.StartsWith("https", StringComparison.OrdinalIgnoreCase)
                     ? ChannelCredentials.SecureSsl
                     : ChannelCredentials.Insecure,
-                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize,
-                MaxSendMessageSize = _config.QueryOptions?.MaxSendMessageSize
+                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize
             });
         _flightClient = new FlightClient(_channel);
         var knownTypes = new List<Type> { typeof(string), typeof(int), typeof(float), typeof(bool) };

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -61,9 +61,9 @@ internal class FlightSqlClient : IFlightSqlClient
                 Credentials = _config.Host.StartsWith("https", StringComparison.OrdinalIgnoreCase)
                     ? ChannelCredentials.SecureSsl
                     : ChannelCredentials.Insecure,
-                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize,
-                MaxSendMessageSize = _config.QueryOptions?.MaxSendMessageSize,
-                CompressionProviders = _config.QueryOptions?.CompressionProviders,
+                MaxReceiveMessageSize = _config.QueryOptions.MaxReceiveMessageSize,
+                MaxSendMessageSize = _config.QueryOptions.MaxSendMessageSize,
+                CompressionProviders = _config.QueryOptions.CompressionProviders,
             });
         _flightClient = new FlightClient(_channel);
         var knownTypes = new List<Type> { typeof(string), typeof(int), typeof(float), typeof(bool) };
@@ -97,7 +97,7 @@ internal class FlightSqlClient : IFlightSqlClient
 
         var ticket = ((IFlightSqlClient)this).PrepareFlightTicket(query, database, queryType, namedParameters);
 
-        using var stream = _flightClient.GetStream(ticket, metadata, _config.QueryOptions?.Deadline);
+        using var stream = _flightClient.GetStream(ticket, metadata, _config.QueryOptions.Deadline);
         while (await stream.ResponseStream.MoveNext().ConfigureAwait(false))
         {
             yield return stream.ResponseStream.Current;

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -61,6 +61,8 @@ internal class FlightSqlClient : IFlightSqlClient
                 Credentials = _config.Host.StartsWith("https", StringComparison.OrdinalIgnoreCase)
                     ? ChannelCredentials.SecureSsl
                     : ChannelCredentials.Insecure,
+                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize,
+                MaxSendMessageSize = _config.QueryOptions?.MaxSendMessageSize
             });
         _flightClient = new FlightClient(_channel);
         var knownTypes = new List<Type> { typeof(string), typeof(int), typeof(float), typeof(bool) };
@@ -94,7 +96,7 @@ internal class FlightSqlClient : IFlightSqlClient
 
         var ticket = ((IFlightSqlClient)this).PrepareFlightTicket(query, database, queryType, namedParameters);
 
-        using var stream = _flightClient.GetStream(ticket, metadata);
+        using var stream = _flightClient.GetStream(ticket, metadata, _config.QueryOptions?.Deadline);
         while (await stream.ResponseStream.MoveNext().ConfigureAwait(false))
         {
             yield return stream.ResponseStream.Current;

--- a/Client/Internal/FlightSqlClient.cs
+++ b/Client/Internal/FlightSqlClient.cs
@@ -61,7 +61,9 @@ internal class FlightSqlClient : IFlightSqlClient
                 Credentials = _config.Host.StartsWith("https", StringComparison.OrdinalIgnoreCase)
                     ? ChannelCredentials.SecureSsl
                     : ChannelCredentials.Insecure,
-                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize
+                MaxReceiveMessageSize = _config.QueryOptions?.MaxReceiveMessageSize,
+                MaxSendMessageSize = _config.QueryOptions?.MaxSendMessageSize,
+                CompressionProviders = _config.QueryOptions?.CompressionProviders,
             });
         _flightClient = new FlightClient(_channel);
         var knownTypes = new List<Type> { typeof(string), typeof(int), typeof(float), typeof(bool) };


### PR DESCRIPTION
Closes #

## Proposed Changes

- Allows setting gRPC options to be passed on. Looks like the C # library does not support a lot of options like other libraries 
- Not sure why codecov complains, I already test that line 100 in FlightSqlClient and coverage more than 80% 🤷 

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
