### PR TITLE
fix: always clone default options

### DIFF
--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -73,7 +73,7 @@ public class ClientConfig
     /// </summary>
     public ClientConfig()
     {
-        QueryOptions = QueryOptions.DefaultOptions;
+        QueryOptions = (QueryOptions)QueryOptions.DefaultOptions.Clone();
     }
 
     /// <summary>
@@ -88,7 +88,7 @@ public class ClientConfig
         AuthScheme = values.Get("authScheme");
         Organization = values.Get("org");
         Database = values.Get("database");
-        QueryOptions = QueryOptions.DefaultOptions;
+        QueryOptions = (QueryOptions)QueryOptions.DefaultOptions.Clone();
         ParsePrecision(values.Get("precision"));
         ParseGzipThreshold(values.Get("gzipThreshold"));
     }
@@ -103,7 +103,7 @@ public class ClientConfig
         AuthScheme = env[EnvInfluxAuthScheme] as string;
         Organization = env[EnvInfluxOrg] as string;
         Database = env[EnvInfluxDatabase] as string;
-        QueryOptions = QueryOptions.DefaultOptions;
+        QueryOptions = (QueryOptions)QueryOptions.DefaultOptions.Clone();
         ParsePrecision(env[EnvInfluxPrecision] as string);
         ParseGzipThreshold(env[EnvInfluxGzipThreshold] as string);
     }

--- a/Client/Config/QueryOptions.cs
+++ b/Client/Config/QueryOptions.cs
@@ -7,7 +7,7 @@ namespace InfluxDB3.Client.Config;
 /// <summary>
 /// Represents the options for configuring query behavior in the client.
 /// </summary>
-public class QueryOptions : ICloneable
+public class QueryOptions : ICloneable, IEquatable<QueryOptions>
 {
     /// <summary>
     /// Gets or sets the optional deadline for query execution.
@@ -70,5 +70,34 @@ public class QueryOptions : ICloneable
     public object Clone()
     {
         return MemberwiseClone();
+    }
+
+    public bool Equals(QueryOptions? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Nullable.Equals(Deadline, other.Deadline) && MaxReceiveMessageSize == other.MaxReceiveMessageSize &&
+               MaxSendMessageSize == other.MaxSendMessageSize &&
+               Equals(CompressionProviders, other.CompressionProviders);
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((QueryOptions)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Deadline.GetHashCode();
+            hashCode = (hashCode * 397) ^ MaxReceiveMessageSize.GetHashCode();
+            hashCode = (hashCode * 397) ^ MaxSendMessageSize.GetHashCode();
+            hashCode = (hashCode * 397) ^ (CompressionProviders != null ? CompressionProviders.GetHashCode() : 0);
+            return hashCode;
+        }
     }
 }

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -27,7 +27,7 @@ namespace InfluxDB3.Client.Config;
 /// }); 
 /// </code>
 /// </summary>
-public class WriteOptions : ICloneable
+public class WriteOptions : ICloneable, IEquatable<WriteOptions>
 {
     /// <summary>
     /// The default precision to use for the timestamp of points if no precision is specified in the write API call.
@@ -66,14 +66,41 @@ public class WriteOptions : ICloneable
     /// </summary>
     public int GzipThreshold { get; set; }
 
-    public object Clone()
-    {
-        return this.MemberwiseClone();
-    }
-
     internal static readonly WriteOptions DefaultOptions = new()
     {
         Precision = WritePrecision.Ns,
         GzipThreshold = 1000
     };
+
+    public object Clone()
+    {
+        return this.MemberwiseClone();
+    }
+
+    public bool Equals(WriteOptions? other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return Precision == other.Precision && Equals(DefaultTags, other.DefaultTags) &&
+               GzipThreshold == other.GzipThreshold;
+    }
+
+    public override bool Equals(object? obj)
+    {
+        if (obj is null) return false;
+        if (ReferenceEquals(this, obj)) return true;
+        if (obj.GetType() != GetType()) return false;
+        return Equals((WriteOptions)obj);
+    }
+
+    public override int GetHashCode()
+    {
+        unchecked
+        {
+            var hashCode = Precision.GetHashCode();
+            hashCode = (hashCode * 397) ^ (DefaultTags != null ? DefaultTags.GetHashCode() : 0);
+            hashCode = (hashCode * 397) ^ GzipThreshold;
+            return hashCode;
+        }
+    }
 }

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -301,7 +301,7 @@ namespace InfluxDB3.Client
                 Database = database,
                 Token = token,
                 AuthScheme = authScheme,
-                WriteOptions = WriteOptions.DefaultOptions
+                WriteOptions = (WriteOptions)WriteOptions.DefaultOptions.Clone()
             })
         {
         }


### PR DESCRIPTION
Closes #

## Proposed Changes

Never use the builtin `DefaultOptions` object as some client could modify it. Always clone it before use.
## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
