### PR TITLE
feat: fast no-sync write support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,16 @@
 1. [#155](https://github.com/InfluxCommunity/influxdb3-csharp/pull/155): Allows setting grpc options.
 1. [#157](https://github.com/InfluxCommunity/influxdb3-csharp/pull/157): Fix: always clone `DefaultOptions` to keep it
    immutable.
+1. [#158](https://github.com/InfluxCommunity/influxdb3-csharp/pull/158): Support fast writes without waiting for WAL
+   persistence:
+    - New write option (`WriteOptions.NoSync`) added: `true` value means faster write but without the confirmation that
+      the data was persisted. Default value: `false`.
+    - **Supported by self-managed InfluxDB 3 Core and Enterprise servers only!**
+    - Also configurable via connection string query parameter (`writeNoSync`).
+    - Also configurable via environment variable (`INFLUX_WRITE_NO_SYNC`).
+    - Long precision string values added from v3 HTTP API: `"nanosecond"`, `"microsecond"`, `"millisecond"`,
+      `"second"` (
+      in addition to the existing `"ns"`, `"us"`, `"ms"`, `"s"`).
 
 ## 1.1.0 [2025-03-26]
 

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -1,6 +1,5 @@
 using System;
-using System.Collections.Frozen;
-using System.Linq;
+using System.Net;
 using System.Threading.Tasks;
 using InfluxDB3.Client.Config;
 using NUnit.Framework;
@@ -32,21 +31,11 @@ public class WriteTest : IntegrationTest
                 Assert.Multiple(() =>
                 {
                     Assert.That(iaex.Message,
-                        Contains.Substring("Found trailing content: 'distance=,status=\"STOPPED\"'"));
+                        Does.Contain("Found trailing content")
+                            .Or.Contain("partial write of line protocol occurred")
+                    );
                     Assert.That(iaex.StatusCode.ToString(), Is.EqualTo("BadRequest"));
-                    Assert.That(iaex.StatusCode, Is.EqualTo(System.Net.HttpStatusCode.BadRequest));
-                });
-                var headersDix = iaex.Headers!.ToFrozenDictionary();
-                Assert.DoesNotThrow(() =>
-                {
-                    Assert.Multiple(() =>
-                    {
-                        Assert.That(headersDix["trace-id"].First(), Is.Not.Empty);
-                        Assert.That(headersDix["trace-sampled"].First(), Is.EqualTo("false"));
-                        Assert.That(headersDix["Strict-Transport-Security"].First(), Is.Not.Empty);
-                        Assert.That(headersDix["X-Influxdb-Request-ID"].First(), Is.Not.Empty);
-                        Assert.That(headersDix["X-Influxdb-Build"].First(), Is.EqualTo("Cloud"));
-                    });
+                    Assert.That(iaex.StatusCode, Is.EqualTo(HttpStatusCode.BadRequest));
                 });
             }
             else

--- a/Client.Test/Write/WritePrecisionConverterTest.cs
+++ b/Client.Test/Write/WritePrecisionConverterTest.cs
@@ -1,0 +1,50 @@
+using System;
+using InfluxDB3.Client.Write;
+
+namespace InfluxDB3.Client.Test.Write
+{
+    public class WritePrecisionConverterTest
+    {
+        [TestCase(WritePrecision.Ns, "ns")]
+        [TestCase(WritePrecision.Us, "us")]
+        [TestCase(WritePrecision.Ms, "ms")]
+        [TestCase(WritePrecision.S, "s")]
+        public void ToV2ApiString_ValidPrecision(WritePrecision precision, string expectedString)
+        {
+            string result = WritePrecisionConverter.ToV2ApiString(precision);
+            Assert.That(expectedString, Is.EqualTo(result));
+        }
+
+        [Test]
+        public void ToV2ApiString_InvalidPrecision()
+        {
+            var ae = Assert.Throws<ArgumentException>(() =>
+            {
+                WritePrecisionConverter.ToV2ApiString((WritePrecision)999);
+            });
+            Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.Message, Does.Contain("Unsupported precision"));
+        }
+
+        [TestCase(WritePrecision.Ns, "nanosecond")]
+        [TestCase(WritePrecision.Us, "microsecond")]
+        [TestCase(WritePrecision.Ms, "millisecond")]
+        [TestCase(WritePrecision.S, "second")]
+        public void ToV3ApiString_ValidPrecision(WritePrecision precision, string expectedString)
+        {
+            string result = WritePrecisionConverter.ToV3ApiString(precision);
+            Assert.That(expectedString, Is.EqualTo(result));
+        }
+
+        [Test]
+        public void ToV3ApiString_InvalidPrecision()
+        {
+            var ae = Assert.Throws<ArgumentException>(() =>
+            {
+                WritePrecisionConverter.ToV3ApiString((WritePrecision)999);
+            });
+            Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.Message, Does.Contain("Unsupported precision"));
+        }
+    }
+}

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -10,6 +10,7 @@ namespace InfluxDB3.Client.Config;
 /// You can configure following options:
 /// - Precision: The default precision to use for the timestamp of points if no precision is specified in the write API call.
 /// - GzipThreshold: The threshold in bytes for gzipping the body. The default value is 1000.
+/// - NoSync: Bool value whether to skip waiting for WAL persistence on write. The default value is false.
 ///
 /// If you want create client with custom options, you can use the following code:
 /// <code>
@@ -22,7 +23,8 @@ namespace InfluxDB3.Client.Config;
 ///     WriteOptions = new WriteOptions
 ///     {
 ///         Precision = WritePrecision.S,
-///         GzipThreshold = 4096
+///         GzipThreshold = 4096,
+///         NoSync = false
 ///     }
 /// }); 
 /// </code>
@@ -66,6 +68,18 @@ public class WriteOptions : ICloneable
     /// </summary>
     public int GzipThreshold { get; set; }
 
+    /// <summary>
+    /// Instructs the server whether to wait with the response until WAL persistence completes.
+    /// NoSync=true means faster write but without the confirmation that the data was persisted.
+    ///
+    /// Note: This option is supported by InfluxDB 3 Core and Enterprise servers only.
+    /// For other InfluxDB 3 server types (InfluxDB Clustered, InfluxDB Clould Serverless/Dedicated)
+    /// the write operation will fail with an error.
+    ///
+    /// Default value: false.
+    /// </summary>
+    public bool NoSync { get; set; }
+
     public object Clone()
     {
         return this.MemberwiseClone();
@@ -74,6 +88,7 @@ public class WriteOptions : ICloneable
     internal static readonly WriteOptions DefaultOptions = new()
     {
         Precision = WritePrecision.Ns,
-        GzipThreshold = 1000
+        GzipThreshold = 1000,
+        NoSync = false,
     };
 }

--- a/Client/Write/WritePrecision.cs
+++ b/Client/Write/WritePrecision.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace InfluxDB3.Client.Write;
 
 /// <summary>
@@ -24,4 +26,31 @@ public enum WritePrecision
     /// Enum Ns for value: ns
     /// </summary>
     Ns = 4
+}
+
+public static class WritePrecisionConverter
+{
+    public static string ToV2ApiString(WritePrecision precision)
+    {
+        return precision switch
+        {
+            WritePrecision.Ns => "ns",
+            WritePrecision.Us => "us",
+            WritePrecision.Ms => "ms",
+            WritePrecision.S => "s",
+            _ => throw new ArgumentException($"Unsupported precision '{precision}'"),
+        };
+    }
+
+    public static string ToV3ApiString(WritePrecision precision)
+    {
+        return precision switch
+        {
+            WritePrecision.Ns => "nanosecond",
+            WritePrecision.Us => "microsecond",
+            WritePrecision.Ms => "millisecond",
+            WritePrecision.S => "second",
+            _ => throw new ArgumentException($"Unsupported precision '{precision}'"),
+        };
+    }
 }


### PR DESCRIPTION
## Proposed Changes

Support fast writes without waiting for WAL persistence:
   - New write option (`WriteOptions.NoSync`) added: `true` value means faster write but without the confirmation that
     the data was persisted. Default value: `false`.
   - **Supported by self-managed InfluxDB 3 Core and Enterprise servers only!**
   - Also configurable via connection string query parameter (`writeNoSync`).
   - Also configurable via environment variable (`INFLUX_WRITE_NO_SYNC`).
   - Long precision string values added from v3 HTTP API: `"nanosecond"`, `"microsecond"`, `"millisecond"`, `"second"` (in addition to the existing `"ns"`, `"us"`, `"ms"`, `"s"`).

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
