### PR TITLE
feat: support create ClientConfig from string and env

### DIFF
--- a/Client.Test/InfluxDBClientTest.cs
+++ b/Client.Test/InfluxDBClientTest.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using InfluxDB3.Client.Config;
 
 // ReSharper disable ObjectCreationAsStatement
 // ReSharper disable AssignNullToNotNullAttribute
@@ -38,6 +39,29 @@ public class InfluxDBClientTest
 
         using var client = new InfluxDBClient();
 
+        Assert.That(client, Is.Not.Null);
+    }
+
+    [Test]
+    public void CreateFromConfigString()
+    {
+        var clientConfig = new ClientConfig("http://localhost:8086?token=my-token&org=my-org&database=my-db");
+        using var client = new InfluxDBClient(clientConfig);
+        Assert.That(client, Is.Not.Null);
+    }
+
+    [Test]
+    public void CreateFromConfigEnv()
+    {
+        var env = new Dictionary<String, String>
+        {
+            {"INFLUX_HOST", "http://localhost:8086"},
+            {"INFLUX_TOKEN", "my-token"},
+            {"INFLUX_ORG", "my-org"},
+            {"INFLUX_DATABASE", "my-database"},
+        };
+        var clientConfig = new ClientConfig(env);
+        using var client = new InfluxDBClient(clientConfig);
         Assert.That(client, Is.Not.Null);
     }
 

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -84,7 +84,7 @@ public class ClientConfig
     /// <summary>
     /// Initializes a new instance of client configuration from connection string.
     /// </summary>
-    internal ClientConfig(string connectionString)
+    public ClientConfig(string connectionString)
     {
         var uri = new Uri(connectionString);
         Host = uri.GetLeftPart(UriPartial.Path);
@@ -102,7 +102,7 @@ public class ClientConfig
     /// <summary>
     /// Initializes a new instance of client configuration from environment variables.
     /// </summary>
-    internal ClientConfig(IDictionary env)
+    public ClientConfig(IDictionary env)
     {
         Host = (string)env[EnvInfluxHost];
         Token = env[EnvInfluxToken] as string;


### PR DESCRIPTION
Closes #

## Proposed Changes

- Allows create ClientConfig from ClientConfig(string connectionString) and ClientConfig(IDictionary env)

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [ ] CHANGELOG.md updated
- [ ] Rebased/mergeable
- [ ] A test has been added if appropriate
- [ ] Tests pass
- [ ] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [ ] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
