### PR TITLE
feat: support partial writes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## 1.9.0 [unreleased]
 
+### Breaking Changes
+
+1. [#258](https://github.com/InfluxCommunity/influxdb3-csharp/pull/258): Adds partial writes support and aligns write routing with v3 defaults.
+   See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
+   For InfluxDB Clustered version, set `UseV2Api=true` for writing.
+
 ## 1.8.0 [2026-04-23]
 
 ### Features

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -25,9 +25,8 @@ public class WriteTest : IntegrationTest
         }
         catch (Exception ex)
         {
-            if (ex is InfluxDBApiException)
+            if (ex is InfluxDBApiException iaex)
             {
-                var iaex = (InfluxDBApiException)ex;
                 Assert.Multiple(() =>
                 {
                     Assert.That(iaex.Message,

--- a/Client.Test/Config/ClientConfigTest.cs
+++ b/Client.Test/Config/ClientConfigTest.cs
@@ -69,7 +69,7 @@ public class ClientConfigTest
     [Test]
     public void CreateFromConnectionStringWithWriteOptions()
     {
-        var cfg = new ClientConfig("http://localhost:8086?token=my-token&org=my-org&database=my-database&precision=s&gzipThreshold=64&writeNoSync=true");
+        var cfg = new ClientConfig("http://localhost:8086?token=my-token&org=my-org&database=my-database&precision=s&gzipThreshold=64&writeNoSync=true&writeAcceptPartial=false&writeUseV2Api=true");
         Assert.That(cfg, Is.Not.Null);
         cfg.Validate();
         Assert.Multiple(() =>
@@ -82,6 +82,8 @@ public class ClientConfigTest
             Assert.That(cfg.WriteOptions.Precision, Is.EqualTo(WritePrecision.S));
             Assert.That(cfg.WriteOptions.GzipThreshold, Is.EqualTo(64));
             Assert.That(cfg.WriteOptions.NoSync, Is.EqualTo(true));
+            Assert.That(cfg.WriteOptions.AcceptPartial, Is.EqualTo(false));
+            Assert.That(cfg.WriteOptions.UseV2Api, Is.EqualTo(true));
         });
     }
 
@@ -221,6 +223,8 @@ public class ClientConfigTest
             {"INFLUX_PRECISION", "s"},
             {"INFLUX_GZIP_THRESHOLD", "64"},
             {"INFLUX_WRITE_NO_SYNC", "true"},
+            {"INFLUX_WRITE_ACCEPT_PARTIAL", "false"},
+            {"INFLUX_WRITE_USE_V2_API", "true"},
         };
         TestUtils.SetEnv(env);
         var cfg = new ClientConfig(env);
@@ -236,6 +240,8 @@ public class ClientConfigTest
             Assert.That(cfg.WriteOptions.Precision, Is.EqualTo(WritePrecision.S));
             Assert.That(cfg.WriteOptions.GzipThreshold, Is.EqualTo(64));
             Assert.That(cfg.WriteOptions.NoSync, Is.EqualTo(true));
+            Assert.That(cfg.WriteOptions.AcceptPartial, Is.EqualTo(false));
+            Assert.That(cfg.WriteOptions.UseV2Api, Is.EqualTo(true));
         });
     }
 

--- a/Client.Test/InfluxDBApiExceptionTest.cs
+++ b/Client.Test/InfluxDBApiExceptionTest.cs
@@ -35,7 +35,7 @@ public class InfluxDBApiExceptionTest : MockServerTest
         var requestId = Guid.NewGuid().ToString();
 
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create()
                 .WithStatusCode(400)
                 .WithBody("{ \"message\": \"just testing\", \"statusCode\": \"bad request\" }")

--- a/Client.Test/InfluxDBClientHttpsTest.cs
+++ b/Client.Test/InfluxDBClientHttpsTest.cs
@@ -242,7 +242,7 @@ public class InfluxDBClientHttpsTest : MockHttpsServerTest
     private async Task WriteData()
     {
         MockHttpsServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1");

--- a/Client.Test/InfluxDBClientWriteTest.cs
+++ b/Client.Test/InfluxDBClientWriteTest.cs
@@ -39,7 +39,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task BodyConcat()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
@@ -55,7 +55,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task BodyPoint()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
@@ -70,7 +70,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task BodyNull()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
@@ -85,7 +85,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task BodyNonDefaultGzipped()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("Content-Encoding", "gzip").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").WithHeader("Content-Encoding", "gzip").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(new ClientConfig
@@ -109,7 +109,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task BodyDefaultNotGzipped()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("Content-Encoding", ".*", MatchBehaviour.RejectOnMatch).UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").WithHeader("Content-Encoding", ".*", MatchBehaviour.RejectOnMatch).UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
@@ -137,7 +137,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task NotSpecifiedOrg()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: null, database: "my-database");
@@ -151,7 +151,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task DefaultTags()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(new ClientConfig
@@ -185,7 +185,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public async Task TagOrder()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         _client = new InfluxDBClient(new ClientConfig
@@ -222,13 +222,13 @@ public class InfluxDBClientWriteTest : MockServerTest
     {
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1", database: "x-database");
 
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Query?["bucket"].First(), Is.EqualTo("x-database"));
+        Assert.That(requests[0].RequestMessage.Query?["db"].First(), Is.EqualTo("x-database"));
     }
 
     [Test]
@@ -251,13 +251,13 @@ public class InfluxDBClientWriteTest : MockServerTest
     {
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1", database: "my-database");
 
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("ns"));
+        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("nanosecond"));
     }
 
     [Test]
@@ -275,13 +275,13 @@ public class InfluxDBClientWriteTest : MockServerTest
             }
         });
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1");
 
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("ms"));
+        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("millisecond"));
     }
 
     [Test]
@@ -289,13 +289,13 @@ public class InfluxDBClientWriteTest : MockServerTest
     {
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1", precision: WritePrecision.S);
 
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("s"));
+        Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("second"));
     }
 
     [Test]
@@ -303,7 +303,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     {
         _client = new InfluxDBClient(MockServerUrl, token: "my-token", organization: "my-org", database: "my-database");
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         var point = PointData.Measurement("h2o")
@@ -333,7 +333,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             }
         });
         MockProxy
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         var point = PointData.Measurement("h2o")
@@ -362,7 +362,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             }
         });
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("X-device", "ab-01").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").WithHeader("X-device", "ab-01").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         var point = PointData.Measurement("h2o")
@@ -392,7 +392,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             Database = "my-database"
         });
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("X-Tracing-ID", "123").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").WithHeader("X-Tracing-ID", "123").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         var point = PointData.Measurement("h2o")
@@ -425,7 +425,7 @@ public class InfluxDBClientWriteTest : MockServerTest
             }
         });
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").WithHeader("X-Client-ID", "456").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").WithHeader("X-Client-ID", "456").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         var point = PointData.Measurement("h2o")
@@ -446,60 +446,62 @@ public class InfluxDBClientWriteTest : MockServerTest
     private async Task WriteData()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1");
     }
 
-    [Test]
-    public async Task WriteNoSyncFalse()
+    private static IEnumerable<TestCaseData> WriteV3OptionCases()
+    {
+        yield return new TestCaseData(new WriteOptions { NoSync = false }, false, false)
+            .SetName("WriteToV3_NoSyncFalse_OmitsNoSyncAndAcceptPartial");
+        yield return new TestCaseData(new WriteOptions { AcceptPartial = false }, false, true)
+            .SetName("WriteToV3_AcceptPartialFalse_AddsAcceptPartialQueryParam");
+        yield return new TestCaseData(new WriteOptions { NoSync = true }, true, false)
+            .SetName("WriteToV3_NoSyncTrue_AddsNoSyncQueryParam");
+    }
+
+    [TestCaseSource(nameof(WriteV3OptionCases))]
+    public async Task WriteToV3OptionCases(WriteOptions writeOptions, bool expectNoSync, bool expectAcceptPartialFalse)
     {
         _client = new InfluxDBClient(new ClientConfig
         {
             Host = MockServerUrl,
             Token = "my-token",
             Database = "my-database",
-            WriteOptions = new WriteOptions
-            {
-                NoSync = false
-            }
-        });
-        MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
-            .RespondWith(Response.Create().WithStatusCode(204));
-
-        await _client.WriteRecordAsync("mem,tag=a field=1");
-
-        var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Path, Is.EqualTo("/api/v2/write"));
-    }
-
-    [Test]
-    public async Task WriteNoSyncTrueSupported()
-    {
-        _client = new InfluxDBClient(new ClientConfig
-        {
-            Host = MockServerUrl,
-            Token = "my-token",
-            Database = "my-database",
-            WriteOptions = new WriteOptions
-            {
-                NoSync = true
-            }
+            WriteOptions = writeOptions
         });
         MockServer
             .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204));
 
         await _client.WriteRecordAsync("mem,tag=a field=1");
-
         var requests = MockServer.LogEntries.ToList();
-        Assert.That(requests[0].RequestMessage.Query?["no_sync"].First(), Is.EqualTo("true"));
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requests[0].RequestMessage.Path, Is.EqualTo("/api/v3/write_lp"));
+            if (expectNoSync)
+            {
+                Assert.That(requests[0].RequestMessage.Query?["no_sync"].First(), Is.EqualTo("true"));
+            }
+            else
+            {
+                Assert.That(requests[0].RequestMessage.Query, Does.Not.ContainKey("no_sync"));
+            }
+            if (expectAcceptPartialFalse)
+            {
+                Assert.That(requests[0].RequestMessage.Query?["accept_partial"].First(), Is.EqualTo("false"));
+            }
+            else
+            {
+                Assert.That(requests[0].RequestMessage.Query, Does.Not.ContainKey("accept_partial"));
+            }
+        }
     }
 
     [Test]
-    public void WriteNoSyncTrueNotSupported()
+    public void WriteNoSyncTrueWithUseV2ApiValidationError()
     {
         _client = new InfluxDBClient(new ClientConfig
         {
@@ -508,15 +510,12 @@ public class InfluxDBClientWriteTest : MockServerTest
             Database = "my-database",
             WriteOptions = new WriteOptions
             {
-                NoSync = true
+                NoSync = true,
+                UseV2Api = true
             }
         });
-        MockServer
-            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
-            .RespondWith(Response.Create().WithStatusCode(HttpStatusCode.MethodNotAllowed));
 
-
-        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
+        var ae = Assert.ThrowsAsync<InvalidOperationException>(async () =>
         {
             await _client.WriteRecordAsync("mem,tag=a field=1");
         });
@@ -524,18 +523,47 @@ public class InfluxDBClientWriteTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(ae, Is.Not.Null);
-            Assert.That(ae.HttpResponseMessage, Is.Not.Null);
-            Assert.That(ae.Message,
-                Does.Contain(
-                    "Server doesn't support write with NoSync=true (supported by InfluxDB 3 Core/Enterprise servers only)."));
+            Assert.That(ae.Message, Is.EqualTo("invalid write options: NoSync cannot be used in V2 API"));
         });
+    }
+
+    [TestCase(true)]
+    [TestCase(false)]
+    public async Task WriteUseV2ApiRoutesToV2AndIgnoresAcceptPartial(bool acceptPartial)
+    {
+        _client = new InfluxDBClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+            Token = "my-token",
+            Database = "my-database",
+            WriteOptions = new WriteOptions
+            {
+                UseV2Api = true,
+                AcceptPartial = acceptPartial
+            }
+        });
+        MockServer
+            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .RespondWith(Response.Create().WithStatusCode(204));
+
+        await _client.WriteRecordAsync("mem,tag=a field=1");
+
+        var requests = MockServer.LogEntries.ToList();
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(requests[0].RequestMessage.Path, Is.EqualTo("/api/v2/write"));
+            Assert.That(requests[0].RequestMessage.Query?["bucket"].First(), Is.EqualTo("my-database"));
+            Assert.That(requests[0].RequestMessage.Query?["precision"].First(), Is.EqualTo("ns"));
+            Assert.That(requests[0].RequestMessage.Query, Does.Not.ContainKey("accept_partial"));
+            Assert.That(requests[0].RequestMessage.Query, Does.Not.ContainKey("no_sync"));
+        }
     }
 
     [Test]
     public void TimeoutExceededByTimeout()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204).WithDelay(TimeSpan.FromSeconds(2)));
 
         _client = new InfluxDBClient(new ClientConfig
@@ -555,7 +583,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public void TimeoutExceededByWriteTimeout()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204).WithDelay(TimeSpan.FromSeconds(2)));
 
         _client = new InfluxDBClient(new ClientConfig
@@ -578,7 +606,7 @@ public class InfluxDBClientWriteTest : MockServerTest
     public void TimeoutExceededByToken()
     {
         MockServer
-            .Given(Request.Create().WithPath("/api/v2/write").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create().WithStatusCode(204).WithDelay(TimeSpan.FromSeconds(2)));
 
         _client = new InfluxDBClient(new ClientConfig

--- a/Client.Test/Internal/RestClientTest.cs
+++ b/Client.Test/Internal/RestClientTest.cs
@@ -238,7 +238,7 @@ public class RestClientTest : MockServerTest
         {
             Assert.That(ae, Is.Not.Null);
             Assert.That(ae.HttpResponseMessage, Is.Not.Null);
-            Assert.That(ae.Message, Is.EqualTo("invalid field value in line protocol for field 'value' on line 0"));
+            Assert.That(ae.Message, Is.EqualTo("parsing failed"));
         });
     }
 
@@ -287,7 +287,7 @@ public class RestClientTest : MockServerTest
                 .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"invalid column type for column 'v', expected iox::column_type::field::integer, got iox::column_type::field::float\",\"line_number\":2,\"original_line\":\"testa6a3ad v=1 17702\"}]}")
                 .WithStatusCode(400));
 
-        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
+        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
         {
             await _client.Request("api", HttpMethod.Post);
         });
@@ -295,11 +295,99 @@ public class RestClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
+            Assert.That(ae.LineErrors[0].LineNumber, Is.EqualTo(2));
+            Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid column type for column 'v', expected iox::column_type::field::integer, got iox::column_type::field::float"));
+            Assert.That(ae.LineErrors[0].OriginalLine, Is.EqualTo("testa6a3ad v=1 17702"));
             Assert.That(ae.HttpResponseMessage, Is.Not.Null);
             Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\tline 2: invalid column type for column 'v', expected iox::column_type::field::integer, got iox::column_type::field::float (testa6a3ad v=1 17702)"));
         });
     }
 
+    [Test]
+    public void ErrorJsonBodyV3WithDataArrayUntypedFallback()
+    {
+        CreateAndConfigureRestClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+        });
+
+        MockServer
+            .Given(Request.Create().WithPath("/api").UsingPost())
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[\"bad line\",true,3]}")
+                .WithStatusCode(400));
+
+        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
+        {
+            await _client.Request("api", HttpMethod.Post);
+        });
+
+        Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\tbad line\n\ttrue\n\t3"));
+    }
+
+    [Test]
+    public void ErrorJsonBodyV3ParsingFailedWriteLpWithDataObject()
+    {
+        CreateAndConfigureRestClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+        });
+
+        MockServer
+            .Given(Request.Create().WithPath("/api").UsingPost())
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":2,\"original_line\":\"m,t=a f=bad\"}}")
+                .WithStatusCode(400));
+
+        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+        {
+            await _client.Request("api", HttpMethod.Post);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
+            Assert.That(ae.LineErrors[0].LineNumber, Is.EqualTo(2));
+            Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid field value"));
+            Assert.That(ae.LineErrors[0].OriginalLine, Is.EqualTo("m,t=a f=bad"));
+            Assert.That(ae.Message, Is.EqualTo("parsing failed for write_lp endpoint:\n\tline 2: invalid field value (m,t=a f=bad)"));
+        });
+    }
+
+    [Test]
+    public void ErrorJsonBodyV3PartialWriteWithDataObjectErrorMessageOnly()
+    {
+        CreateAndConfigureRestClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+        });
+
+        MockServer
+            .Given(Request.Create().WithPath("/api").UsingPost())
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"invalid field value\"}}")
+                .WithStatusCode(400));
+
+        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+        {
+            await _client.Request("api", HttpMethod.Post);
+        });
+
+        Assert.Multiple(() =>
+        {
+            Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
+            Assert.That(ae.LineErrors[0].LineNumber, Is.EqualTo(0));
+            Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid field value"));
+            Assert.That(ae.LineErrors[0].OriginalLine, Is.Null);
+            Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\tinvalid field value"));
+        });
+    }
 
     [Test]
     public void ErrorReason()

--- a/Client/Client.csproj
+++ b/Client/Client.csproj
@@ -41,6 +41,7 @@
 
     <ItemGroup>
         <PackageReference Include="Apache.Arrow.Flight" Version="22.1.0" />
+        <PackageReference Include="System.Text.Json" Version="10.0.5" />
     </ItemGroup>
 
     <ItemGroup>

--- a/Client/Config/ClientConfig.cs
+++ b/Client/Config/ClientConfig.cs
@@ -70,6 +70,8 @@ public class ClientConfig
     internal const string EnvInfluxPrecision = "INFLUX_PRECISION";
     internal const string EnvInfluxGzipThreshold = "INFLUX_GZIP_THRESHOLD";
     internal const string EnvInfluxWriteNoSync = "INFLUX_WRITE_NO_SYNC";
+    internal const string EnvInfluxWriteAcceptPartial = "INFLUX_WRITE_ACCEPT_PARTIAL";
+    internal const string EnvInfluxWriteUseV2Api = "INFLUX_WRITE_USE_V2_API";
     internal const string EnvInfluxDisableGrpcCompression = "INFLUX_DISABLE_GRPC_COMPRESSION";
 
     private string _host = "";
@@ -98,6 +100,8 @@ public class ClientConfig
         ParsePrecision(values.Get("precision"));
         ParseGzipThreshold(values.Get("gzipThreshold"));
         ParseWriteNoSync(values.Get("writeNoSync"));
+        ParseWriteAcceptPartial(values.Get("writeAcceptPartial"));
+        ParseWriteUseV2Api(values.Get("writeUseV2Api"));
         ParseDisableGrpcCompression(values.Get("disableGrpcCompression"));
     }
 
@@ -115,6 +119,8 @@ public class ClientConfig
         ParsePrecision(env[EnvInfluxPrecision] as string);
         ParseGzipThreshold(env[EnvInfluxGzipThreshold] as string);
         ParseWriteNoSync(env[EnvInfluxWriteNoSync] as string);
+        ParseWriteAcceptPartial(env[EnvInfluxWriteAcceptPartial] as string);
+        ParseWriteUseV2Api(env[EnvInfluxWriteUseV2Api] as string);
         ParseDisableGrpcCompression(env[EnvInfluxDisableGrpcCompression] as string);
     }
 
@@ -243,6 +249,16 @@ public class ClientConfig
         get => (WriteOptions ?? WriteOptions.DefaultOptions).NoSync;
     }
 
+    internal bool WriteAcceptPartial
+    {
+        get => (WriteOptions ?? WriteOptions.DefaultOptions).AcceptPartial;
+    }
+
+    internal bool WriteUseV2Api
+    {
+        get => (WriteOptions ?? WriteOptions.DefaultOptions).UseV2Api;
+    }
+
     private void ParsePrecision(string? precision)
     {
         if (precision != null)
@@ -281,6 +297,26 @@ public class ClientConfig
             var noSync = bool.Parse(strVal);
             WriteOptions ??= (WriteOptions)WriteOptions.DefaultOptions.Clone();
             WriteOptions.NoSync = noSync;
+        }
+    }
+
+    private void ParseWriteAcceptPartial(string? strVal)
+    {
+        if (strVal != null)
+        {
+            var acceptPartial = bool.Parse(strVal);
+            WriteOptions ??= (WriteOptions)WriteOptions.DefaultOptions.Clone();
+            WriteOptions.AcceptPartial = acceptPartial;
+        }
+    }
+
+    private void ParseWriteUseV2Api(string? strVal)
+    {
+        if (strVal != null)
+        {
+            var useV2Api = bool.Parse(strVal);
+            WriteOptions ??= (WriteOptions)WriteOptions.DefaultOptions.Clone();
+            WriteOptions.UseV2Api = useV2Api;
         }
     }
 

--- a/Client/Config/WriteOptions.cs
+++ b/Client/Config/WriteOptions.cs
@@ -12,6 +12,8 @@ namespace InfluxDB3.Client.Config;
 /// - GzipThreshold: The threshold in bytes for gzipping the body. The default value is 1000.
 /// - TagOrder: Preferred tag order for line protocol serialization.
 /// - NoSync: Bool value whether to skip waiting for WAL persistence on write. The default value is false.
+/// - AcceptPartial: Allow partial writes on v3 write endpoint. The default value is true.
+/// - UseV2Api: Route writes to v2 compatibility endpoint (/api/v2/write). The default value is false.
 ///
 /// If you want create client with custom options, you can use the following code:
 /// <code>
@@ -88,9 +90,30 @@ public class WriteOptions : ICloneable
     /// </summary>
     public bool NoSync { get; set; }
 
+    /// <summary>
+    /// Controls partial-write behavior on the v3 write endpoint.
+    /// true (default): allow partial writes (server default behavior)
+    /// false: reject the full batch when any line fails.
+    /// </summary>
+    public bool AcceptPartial { get; set; } = true;
+
+    /// <summary>
+    /// Routes writes to the v2 compatibility endpoint (/api/v2/write).
+    /// Intended for InfluxDB Clustered/v2-compatible backends.
+    /// </summary>
+    public bool UseV2Api { get; set; } = false;
+
     public object Clone()
     {
         return this.MemberwiseClone();
+    }
+
+    internal void Validate()
+    {
+        if (UseV2Api && NoSync)
+        {
+            throw new InvalidOperationException("invalid write options: NoSync cannot be used in V2 API");
+        }
     }
 
     internal static readonly WriteOptions DefaultOptions = new()
@@ -98,5 +121,7 @@ public class WriteOptions : ICloneable
         Precision = WritePrecision.Ns,
         GzipThreshold = 1000,
         NoSync = false,
+        AcceptPartial = true,
+        UseV2Api = false,
     };
 }

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -352,7 +352,9 @@ namespace InfluxDB3.Client
         /// <description>precision - timestamp precision when writing data (<c>ns</c> (default), <c>us</c>, <c>ms</c>, <c>s</c>)</description>
         /// </item>
         /// <item>
-        /// <description>gzipThreshold - threshold for gzip data when writing (default is <c>1000</c>)</description>
+        /// <description>gzipThreshold - threshold for gzip data when writing (default is <c>1000</c>).</description>
+        /// <description>writeAcceptPartial - allow partial writes on v3 write endpoint (default is <c>true</c>)</description>
+        /// <description>writeUseV2Api - route writes to v2 compatibility endpoint (default is <c>false</c>)</description>
         /// </item>
         /// <item>
         /// <description>writeNoSync - bool value whether to skip waiting for WAL persistence on write (default is <c>false</c>)</description>
@@ -394,6 +396,8 @@ namespace InfluxDB3.Client
         /// <item>
         /// <description>INFLUX_GZIP_THRESHOLD - threshold for gzipping data when writing (default is <c>1000</c>)</description>
         /// </item>
+        /// <description>INFLUX_WRITE_ACCEPT_PARTIAL - allow partial writes on v3 write endpoint (default is <c>true</c>)</description>
+        /// <description>INFLUX_WRITE_USE_V2_API - route writes to v2 compatibility endpoint (default is <c>false</c>)</description>
         /// <item>
         /// <description>INFLUX_WRITE_NO_SYNC - bool value whether to skip waiting for WAL persistence on write (default is <c>false</c>)</description>
         /// </item>
@@ -765,25 +769,15 @@ namespace InfluxDB3.Client
             var body = sb.ToString();
             var content = _gzipHandler.Process(body) ?? new StringContent(body, Encoding.UTF8, "text/plain");
 
+            var writeOptions = _config.WriteOptions ?? WriteOptions.DefaultOptions;
+            writeOptions.Validate();
+
             string path;
             Dictionary<string, string?> queryParams;
             var databaseNotNull
                 = (database ?? _config.Database) ?? throw new InvalidOperationException(OptionMessage("database"));
-            if (_config.WriteNoSync)
+            if (writeOptions.UseV2Api)
             {
-                // Setting no_sync=true is supported only in the v3 API.
-                path = "api/v3/write_lp";
-                queryParams = new Dictionary<string, string?>()
-                {
-                    { "org", _config.Organization },
-                    { "db", databaseNotNull },
-                    { "precision", WritePrecisionConverter.ToV3ApiString(precisionNotNull) },
-                    { "no_sync", "true" }
-                };
-            }
-            else
-            {
-                // By default, use the v2 API.
                 path = "api/v2/write";
                 queryParams = new Dictionary<string, string?>()
                 {
@@ -791,6 +785,25 @@ namespace InfluxDB3.Client
                     { "bucket", databaseNotNull },
                     { "precision", WritePrecisionConverter.ToV2ApiString(precisionNotNull) },
                 };
+            }
+            else
+            {
+                path = "api/v3/write_lp";
+                queryParams = new Dictionary<string, string?>()
+                {
+                    { "org", _config.Organization },
+                    { "db", databaseNotNull },
+                    { "precision", WritePrecisionConverter.ToV3ApiString(precisionNotNull) },
+                };
+
+                if (writeOptions.NoSync)
+                {
+                    queryParams["no_sync"] = "true";
+                }
+                if (!writeOptions.AcceptPartial)
+                {
+                    queryParams["accept_partial"] = "false";
+                }
             }
 
             var cancelToken = new CancellationTokenSource(_config.Timeout).Token; // Just for compatibility with the old API
@@ -803,21 +816,9 @@ namespace InfluxDB3.Client
                 cancelToken = new CancellationTokenSource(_config.WriteTimeout.Value).Token;
             }
 
-            try
-            {
-                await _restClient
-                    .Request(path, HttpMethod.Post, content, queryParams, headers, cancelToken)
-                    .ConfigureAwait(false);
-            }
-            catch (InfluxDBApiException e)
-            {
-                if (_config.WriteNoSync && e.StatusCode == HttpStatusCode.MethodNotAllowed)
-                {
-                    // Server does not support the v3 write API, can't use the NoSync option.
-                    throw new InfluxDBApiException("Server doesn't support write with NoSync=true (supported by InfluxDB 3 Core/Enterprise servers only).", e.HttpResponseMessage!);
-                }
-                throw;
-            }
+            await _restClient
+                .Request(path, HttpMethod.Post, content, queryParams, headers, cancelToken)
+                .ConfigureAwait(false);
         }
 
         /// <summary>

--- a/Client/InfluxDBClient.cs
+++ b/Client/InfluxDBClient.cs
@@ -353,7 +353,11 @@ namespace InfluxDB3.Client
         /// </item>
         /// <item>
         /// <description>gzipThreshold - threshold for gzip data when writing (default is <c>1000</c>).</description>
+        /// </item>
+        /// <item>
         /// <description>writeAcceptPartial - allow partial writes on v3 write endpoint (default is <c>true</c>)</description>
+        /// </item>
+        /// <item>
         /// <description>writeUseV2Api - route writes to v2 compatibility endpoint (default is <c>false</c>)</description>
         /// </item>
         /// <item>
@@ -396,8 +400,12 @@ namespace InfluxDB3.Client
         /// <item>
         /// <description>INFLUX_GZIP_THRESHOLD - threshold for gzipping data when writing (default is <c>1000</c>)</description>
         /// </item>
+        /// <item>
         /// <description>INFLUX_WRITE_ACCEPT_PARTIAL - allow partial writes on v3 write endpoint (default is <c>true</c>)</description>
+        /// </item>
+        /// <item>
         /// <description>INFLUX_WRITE_USE_V2_API - route writes to v2 compatibility endpoint (default is <c>false</c>)</description>
+        /// </item>
         /// <item>
         /// <description>INFLUX_WRITE_NO_SYNC - bool value whether to skip waiting for WAL persistence on write (default is <c>false</c>)</description>
         /// </item>

--- a/Client/InfluxDBPartialWriteException.cs
+++ b/Client/InfluxDBPartialWriteException.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Net.Http;
+
+namespace InfluxDB3.Client;
+
+/// <summary>
+/// API exception with structured per-line details for v3 partial-write errors.
+/// </summary>
+public class InfluxDBPartialWriteException : InfluxDBApiException
+{
+    public sealed class LineError
+    {
+        public LineError(int lineNumber, string errorMessage, string? originalLine)
+        {
+            LineNumber = lineNumber;
+            ErrorMessage = errorMessage;
+            OriginalLine = originalLine;
+        }
+
+        public int LineNumber { get; }
+
+        public string ErrorMessage { get; }
+
+        public string? OriginalLine { get; }
+    }
+
+    internal InfluxDBPartialWriteException(
+        string message,
+        HttpResponseMessage httpResponseMessage,
+        IReadOnlyList<LineError> lineErrors) : base(message, httpResponseMessage)
+    {
+        LineErrors = lineErrors;
+    }
+
+    /// <summary>
+    /// Structured line-level errors returned by the v3 write endpoint.
+    /// </summary>
+    public IReadOnlyList<LineError> LineErrors { get; }
+}

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -1,12 +1,11 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
-using System.IO;
 using System.Linq;
 using System.Net.Http;
 using System.Runtime.Serialization;
-using System.Runtime.Serialization.Json;
 using System.Text;
+using System.Text.Json;
 using System.Threading;
 using System.Threading.Tasks;
 using System.Web;
@@ -82,10 +81,11 @@ internal class RestClient
         var result = await _httpClient.SendAsync(request, cancellationToken).ConfigureAwait(false);
         if (!result.IsSuccessStatusCode)
         {
-            string? message = null;
             var body = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
             var contentType = result.Content?.Headers?.ContentType?.ToString();
-            message = FormatErrorMessage(body, contentType);
+            var parsed = ParseErrorMessage(body, contentType);
+            var message = parsed.Message;
+            var partialLineErrors = parsed.PartialLineErrors;
 
             // from header
             if (string.IsNullOrEmpty(message))
@@ -108,138 +108,243 @@ internal class RestClient
                 message = result.ReasonPhrase;
             }
 
+            if (partialLineErrors?.Count > 0)
+            {
+                throw new InfluxDBPartialWriteException(message ?? "Cannot write data to InfluxDB.", result, partialLineErrors);
+            }
+
             throw new InfluxDBApiException(message ?? "Cannot write data to InfluxDB.", result);
         }
 
         return result;
     }
 
-    private static string? FormatErrorMessage(string body, string? contentType)
+    private static ParsedErrorMessage ParseErrorMessage(string body, string? contentType)
     {
-        if (string.IsNullOrEmpty(body))
+        if (string.IsNullOrWhiteSpace(body))
         {
-            return null;
+            return ParsedErrorMessage.Empty;
         }
+
         if (!string.IsNullOrEmpty(contentType) &&
             !contentType.StartsWith("application/json", StringComparison.OrdinalIgnoreCase))
         {
-            return null;
-        }
-
-        string? message = null;
-        try
-        {
-            using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
-            if (new DataContractJsonSerializer(typeof(ErrorBody)).ReadObject(memoryStream) is ErrorBody errorBody)
-            {
-                if (!string.IsNullOrEmpty(errorBody.Message)) // Cloud
-                {
-                    message = errorBody.Message;
-                }
-                else if ((errorBody.Data is not null) && !string.IsNullOrEmpty(errorBody.Data.ErrorMessage)) // v3/Core/Enterprise (legacy object form)
-                {
-                    message = errorBody.Data.ErrorMessage;
-                }
-                else if (!string.IsNullOrEmpty(errorBody.Error)) // v3/Core/Enterprise
-                {
-                    message = errorBody.Error;
-                }
-            }
-        }
-        catch (SerializationException se)
-        {
-            Debug.WriteLine($"Cannot parse error response as legacy JSON format: {body}. {se}");
+            return ParsedErrorMessage.Empty;
         }
 
         try
         {
-            using var memoryStream = new MemoryStream(Encoding.UTF8.GetBytes(body));
-            if (new DataContractJsonSerializer(typeof(V3ErrorBody)).ReadObject(memoryStream) is V3ErrorBody v3ErrorBody)
-            {
-                var v3Message = BuildV3ErrorMessage(v3ErrorBody);
-                var hasV3Details = v3ErrorBody.Data?.Any(detail => !string.IsNullOrEmpty(detail.ErrorMessage)) == true;
-                if (!string.IsNullOrEmpty(v3Message) && (string.IsNullOrEmpty(message) || hasV3Details))
-                {
-                    message = v3Message;
-                }
-            }
-        }
-        catch (SerializationException se)
-        {
-            Debug.WriteLine($"Cannot parse error response as v3 JSON format: {body}. {se}");
-        }
+            using var document = JsonDocument.Parse(body);
+            var root = document.RootElement;
 
-        return message;
+            var cloudMessage = GetStringProperty(root, "message");
+            var topLevelError = GetStringProperty(root, "error");
+            var data = GetProperty(root, "data");
+
+            var legacyDataMessage = GetLegacyDataErrorMessage(data);
+            var message = cloudMessage ?? topLevelError ?? legacyDataMessage;
+            var partial = ParsePartialWrite(topLevelError, data);
+            if (partial is not null)
+            {
+                return partial;
+            }
+
+            return new ParsedErrorMessage(message, null);
+        }
+        catch (JsonException se)
+        {
+            Debug.WriteLine($"Cannot parse error response as JSON format: {body}. {se}");
+            return ParsedErrorMessage.Empty;
+        }
     }
 
-    private static string? BuildV3ErrorMessage(V3ErrorBody v3ErrorBody)
+    private static ParsedErrorMessage? ParsePartialWrite(string? topLevelError, JsonElement? data)
     {
-        if (string.IsNullOrEmpty(v3ErrorBody.Error))
+        if (string.IsNullOrEmpty(topLevelError) || !IsPartialWriteError(topLevelError))
+        {
+            return null;
+        }
+        if (data is null)
         {
             return null;
         }
 
-        var message = new StringBuilder(v3ErrorBody.Error);
+        if (data.Value.ValueKind == JsonValueKind.Array)
+        {
+            if (TryParseTypedLineErrors(data.Value, out var lineErrors))
+            {
+                return new ParsedErrorMessage(BuildPartialWriteMessage(topLevelError, lineErrors), lineErrors);
+            }
+
+            var details = data.Value.EnumerateArray()
+                .Where(item => item.ValueKind != JsonValueKind.Null)
+                .Select(ToDetailString)
+                .Where(item => !string.IsNullOrEmpty(item))
+                .ToList();
+
+            if (details.Count > 0)
+            {
+                return new ParsedErrorMessage($"{topLevelError}:\n\t{string.Join("\n\t", details)}", null);
+            }
+
+            return null;
+        }
+
+        if (data.Value.ValueKind == JsonValueKind.Object)
+        {
+            if (TryParseTypedLineError(data.Value, out var lineError))
+            {
+                var lineErrors = new List<InfluxDBPartialWriteException.LineError> { lineError };
+                return new ParsedErrorMessage(BuildPartialWriteMessage(topLevelError, lineErrors), lineErrors);
+            }
+
+            return null;
+        }
+
+        return null;
+    }
+
+    private static string BuildPartialWriteMessage(
+        string baseMessage,
+        IEnumerable<InfluxDBPartialWriteException.LineError> lineErrors)
+    {
+        var message = new StringBuilder(baseMessage);
         var hasDetails = false;
-        foreach (var detail in (v3ErrorBody.Data ?? Enumerable.Empty<V3ErrorBody.V3ErrorData>())
-                     .Where(detail => !string.IsNullOrEmpty(detail.ErrorMessage)))
+        foreach (var detail in lineErrors)
         {
             if (!hasDetails)
             {
                 message.Append(':');
                 hasDetails = true;
             }
-            var lineNumber = detail.LineNumber?.ToString() ?? "?";
-            message.Append($"\n\tline {lineNumber}: {detail.ErrorMessage}");
-            if (!string.IsNullOrEmpty(detail.OriginalLine))
+            if (detail.LineNumber != 0 && !string.IsNullOrEmpty(detail.OriginalLine))
             {
-                message.Append($" ({detail.OriginalLine})");
+                message.Append($"\n\tline {detail.LineNumber}: {detail.ErrorMessage} ({detail.OriginalLine})");
+            }
+            else if (!string.IsNullOrEmpty(detail.ErrorMessage))
+            {
+                message.Append($"\n\t{detail.ErrorMessage}");
+            }
+            else
+            {
+                message.Append($"\n\tline {detail.LineNumber}: {detail.ErrorMessage}");
             }
         }
+
         return message.ToString();
     }
-}
 
-[DataContract]
-internal class ErrorBody
-{
-    [DataMember(Name = "message")]
-    public string? Message { get; set; }
-
-    [DataMember(Name = "error")]
-    public string? Error { get; set; }
-
-    [DataMember(Name = "data")]
-    public ErrorData? Data { get; set; }
-
-    [DataContract]
-    internal class ErrorData
+    private static bool IsPartialWriteError(string topLevelError)
     {
-        [DataMember(Name = "error_message")]
-        public string? ErrorMessage { get; set; }
+        return topLevelError.IndexOf("partial write of line protocol occurred", StringComparison.OrdinalIgnoreCase) >= 0 ||
+               topLevelError.IndexOf("parsing failed for write_lp endpoint", StringComparison.OrdinalIgnoreCase) >= 0;
     }
-}
 
-[DataContract]
-internal class V3ErrorBody
-{
-    [DataMember(Name = "error")]
-    public string? Error { get; set; }
-
-    [DataMember(Name = "data")]
-    public List<V3ErrorData>? Data { get; set; }
-
-    [DataContract]
-    internal class V3ErrorData
+    private static bool TryParseTypedLineErrors(
+        JsonElement data,
+        out List<InfluxDBPartialWriteException.LineError> lineErrors)
     {
-        [DataMember(Name = "error_message")]
-        public string? ErrorMessage { get; set; }
+        lineErrors = new List<InfluxDBPartialWriteException.LineError>();
+        if (data.ValueKind != JsonValueKind.Array)
+        {
+            return false;
+        }
 
-        [DataMember(Name = "line_number")]
-        public int? LineNumber { get; set; }
+        foreach (var item in data.EnumerateArray())
+        {
+            if (!TryParseTypedLineError(item, out var lineError))
+            {
+                lineErrors.Clear();
+                return false;
+            }
 
-        [DataMember(Name = "original_line")]
-        public string? OriginalLine { get; set; }
+            lineErrors.Add(lineError);
+        }
+
+        return lineErrors.Count > 0;
+    }
+
+    private static bool TryParseTypedLineError(JsonElement item, out InfluxDBPartialWriteException.LineError lineError)
+    {
+        lineError = null!;
+        if (item.ValueKind != JsonValueKind.Object)
+        {
+            return false;
+        }
+
+        var errorMessage = GetProperty(item, "error_message");
+        var lineNumber = GetProperty(item, "line_number");
+        var originalLine = GetProperty(item, "original_line");
+        if (errorMessage?.ValueKind != JsonValueKind.String || string.IsNullOrEmpty(errorMessage.Value.GetString()))
+        {
+            return false;
+        }
+
+        var number = 0;
+        if (lineNumber is not null)
+        {
+            if (lineNumber.Value.ValueKind != JsonValueKind.Number || !lineNumber.Value.TryGetInt32(out number))
+            {
+                return false;
+            }
+        }
+
+        string? original = null;
+        if (originalLine is not null)
+        {
+            if (originalLine.Value.ValueKind != JsonValueKind.String)
+            {
+                return false;
+            }
+
+            original = originalLine.Value.GetString();
+        }
+
+        lineError = new InfluxDBPartialWriteException.LineError(
+            number,
+            errorMessage.Value.GetString()!,
+            original);
+        return true;
+    }
+
+    private static JsonElement? GetProperty(JsonElement element, string propertyName)
+    {
+        return element.TryGetProperty(propertyName, out var value) ? value : null;
+    }
+
+    private static string? GetStringProperty(JsonElement element, string propertyName)
+    {
+        return GetProperty(element, propertyName) is { ValueKind: JsonValueKind.String } value ? value.GetString() : null;
+    }
+
+    private static string? GetLegacyDataErrorMessage(JsonElement? data)
+    {
+        if (data is null || data.Value.ValueKind != JsonValueKind.Object)
+        {
+            return null;
+        }
+
+        var errorMessage = GetProperty(data.Value, "error_message");
+        return errorMessage?.ValueKind == JsonValueKind.String ? errorMessage?.GetString() : null;
+    }
+
+    private static string ToDetailString(JsonElement element)
+    {
+        return element.ValueKind == JsonValueKind.String ? (element.GetString() ?? "") : element.GetRawText();
+    }
+
+    private sealed class ParsedErrorMessage
+    {
+        internal static readonly ParsedErrorMessage Empty = new(null, null);
+
+        internal ParsedErrorMessage(string? message, List<InfluxDBPartialWriteException.LineError>? partialLineErrors)
+        {
+            Message = message;
+            PartialLineErrors = partialLineErrors;
+        }
+
+        internal string? Message { get; }
+        internal List<InfluxDBPartialWriteException.LineError>? PartialLineErrors { get; }
     }
 }
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,9 @@ public class IOxExample
 }
 ```
 
-to insert data, you can use code like this:
+### Write
+
+To write data, you can use code like this:
 
 ```csharp
 //
@@ -101,7 +103,60 @@ const string record = "temperature,location=north value=60.0";
 await client.WriteRecordAsync(record: record);
 ```
 
-to query your data, you can use code like this:
+#### Partial Writes
+
+Use `WriteOptions.AcceptPartial` to control whether a v3 write can partially succeed when some lines fail.
+Default is `true` (server default). When `false`, the full batch is rejected.
+
+```csharp
+using var client = new InfluxDBClient(new ClientConfig
+{
+    Host = host,
+    Token = token,
+    Database = database,
+    WriteOptions = new WriteOptions()
+});
+
+try
+{
+    await client.WriteRecordAsync(lp);
+}
+catch (InfluxDBPartialWriteException e)
+{
+    foreach (var lineErr in e.LineErrors)
+    {
+        Console.WriteLine(
+            $"line {lineErr.LineNumber} failed: {lineErr.ErrorMessage} ({lineErr.OriginalLine})");
+    }
+}
+catch (InfluxDBApiException e)
+{
+    Console.WriteLine(e.Message);
+}
+```
+
+See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) for more.
+
+#### Use V2 API Compatibility Mode
+
+By default, writes use `/api/v3/write_lp`.
+For InfluxDB Clustered/v2-compatible backends, set `UseV2Api=true` to route writes to `/api/v2/write`.
+
+`UseV2Api` can be configured in three ways:
+
+1. `WriteOptions.UseV2Api`
+2. Connection string `writeUseV2Api`
+3. Environment variable `INFLUX_WRITE_USE_V2_API`
+
+`AcceptPartial` can be configured in three ways:
+
+1. `WriteOptions.AcceptPartial`
+2. Connection string `writeAcceptPartial`
+3. Environment variable `INFLUX_WRITE_ACCEPT_PARTIAL`
+
+### Query
+
+To query your data, you can use code like this:
 
 ```csharp
 //


### PR DESCRIPTION
## Proposed Changes

Adds partial-write support with structured error details in `InfluxDBPartialWriteException`, including per-line `LineNumber`, `ErrorMessage`, and `OriginalLine` so callers can decide whether to drop/retry/fix specific lines in a ba
tch.

This also aligns write routing with the rollout contract:

- Default write endpoint is now `/api/v3/write_lp`
- `AcceptPartial` defaults to `true` (server default behavior)
- `accept_partial=false` is sent only when partial writes are explicitly disabled
- New compatibility option `UseV2Api` routes writes to `/api/v2/write` for Clustered/v2-compatible backends

Configuration surfaces now include:

- Write option: `AcceptPartial`, `UseV2Api`
- Client config / connection string keys: `writeAcceptPartial`, `writeUseV2Api`
- Environment variables: `INFLUX_WRITE_ACCEPT_PARTIAL`, `INFLUX_WRITE_USE_V2_API`

Validation:

- `UseV2Api=true` with `NoSync=true` is rejected before request dispatch.

See [Partial writes](https://docs.influxdata.com/influxdb3/core/write-data/http-api/v3-write-lp/#partial-writes) in InfluxDB documentation.

Example:

```csharp
try
{
    await client.WriteRecordAsync(lp); // AcceptPartial=true by default
}
catch (InfluxDBPartialWriteException e)
{
    foreach (var lineErr in e.LineErrors)
    {
        Console.WriteLine(
            $"line {lineErr.LineNumber} failed: {lineErr.ErrorMessage} ({lineErr.OriginalLine})");
    }
}
catch (InfluxDBApiException e)
{
    Console.WriteLine(e.Message);
}
```

Optional v2 compatibility mode:

```csharp
using var v2Client = new InfluxDBClient(new ClientConfig
{
    Host = host,
    Token = token,
    Database = database,
    WriteOptions = new WriteOptions
    {
        UseV2Api = true
    }
});

await v2Client.WriteRecordAsync(lp);
```

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
