### PR TITLE
fix: partial write error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 ## 1.11.0 [unreleased]
 
+### Bug Fixes
+
+1. [#318](https://github.com/InfluxCommunity/influxdb3-csharp/pull/318):
+   - Only throws `InfluxDBPartialWriteException` when:
+     - Error response status code is `400`.
+     - Error response format `{"error":"...","data":[{"error_message":"...","line_number":2,"original_line": "..."}]}` is returned with `data` must be an array.
+     - `accept_partial` is set to `true`.
+     - Write endpoint must be `api/v3/write_lp`.
+
 ## 1.10.0 [2026-08-27]
 
 ### Features

--- a/Client.Test.Integration/WriteTest.cs
+++ b/Client.Test.Integration/WriteTest.cs
@@ -51,7 +51,7 @@ public class WriteTest : IntegrationTest
 
     [TestCase(false, true, true, TestName = "WritePartialBatch_WithV3Api_ReturnsStructuredPartialWriteError")]
     [TestCase(true, false, true, TestName = "WritePartialBatch_WithV2Api_ReturnsGenericApiError")]
-    [TestCase(false, true, false, TestName = "WritePartialBatch_WithV3Api_AcceptPartialFalse_ReturnsStructuredPartialWriteError")]
+    [TestCase(false, false, false, TestName = "WritePartialBatch_WithV3Api_AcceptPartialFalse_ReturnsGenericApiError")]
     [TestCase(true, false, false, TestName = "WritePartialBatch_WithV2Api_AcceptPartialFalse_ReturnsGenericApiError")]
     public void WritePartialBatchBehaviorByWriteApi(bool useV2Api, bool expectStructuredPartialError, bool acceptPartial)
     {

--- a/Client.Test/Internal/RestClientTest.cs
+++ b/Client.Test/Internal/RestClientTest.cs
@@ -396,7 +396,8 @@ public class RestClientTest : MockServerTest
             .Given(Request.Create().WithPath("/api").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
-                .WithBody("{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":2,\"original_line\":\"home,room=Sunroom temp=hi 1735549200\"}}")
+                .WithBody(
+                    "{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":2,\"original_line\":\"home,room=Sunroom temp=hi 1735549200\"}}")
                 .WithStatusCode(400));
 
         var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
@@ -407,7 +408,9 @@ public class RestClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(ae, Is.Not.Null);
-            Assert.That(ae.Message, Is.EqualTo("parsing failed for write_lp endpoint:\n\tline 2: invalid field value (home,room=Sunroom temp=hi 1735549200)"));
+            Assert.That(ae.Message,
+                Is.EqualTo(
+                    "parsing failed for write_lp endpoint:\n\tline 2: invalid field value (home,room=Sunroom temp=hi 1735549200)"));
         });
     }
 
@@ -438,7 +441,7 @@ public class RestClientTest : MockServerTest
             Assert.That(ae.Message, Is.EqualTo("parsing failed for write_lp endpoint:\n\tinvalid field value"));
         });
     }
-    
+
     [Test]
     public void ErrorJsonBodyV3PartialWriteWithDataObjectErrorMessageOnly()
     {
@@ -451,7 +454,8 @@ public class RestClientTest : MockServerTest
             .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
-                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"invalid field value\"}]}")
+                .WithBody(
+                    "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"invalid field value\"}]}")
                 .WithStatusCode(400));
 
         var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>

--- a/Client.Test/Internal/RestClientTest.cs
+++ b/Client.Test/Internal/RestClientTest.cs
@@ -1,5 +1,7 @@
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Threading.Tasks;
@@ -226,7 +228,8 @@ public class RestClientTest : MockServerTest
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("X-Influx-Error", "not used")
-                .WithBody("{\"error\":\"parsing failed\", \"data\":{\"error_message\":\"invalid field value in line protocol for field 'value' on line 0\"}}")
+                .WithBody("{\"error\":\"parsing failed\",\"data\":" +
+                          "{\"error_message\":\"invalid field value in line protocol for field 'value' on line 0\"}}")
                 .WithStatusCode(401));
 
         var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
@@ -239,7 +242,7 @@ public class RestClientTest : MockServerTest
             Assert.That(ae, Is.Not.Null);
             Assert.That(ae.HttpResponseMessage, Is.Not.Null);
             Assert.That(ae.Message, Is.EqualTo(
-                "parsing failed: invalid field value in line protocol for field 'value' on line 0"));
+                "parsing failed:\n\tinvalid field value in line protocol for field 'value' on line 0"));
         });
     }
 
@@ -293,7 +296,7 @@ public class RestClientTest : MockServerTest
         });
 
         Assert.That(ae, Is.Not.Null);
-        Assert.That(ae!.Message, Is.EqualTo("parsing failed: invalid field value"));
+        Assert.That(ae!.Message, Is.EqualTo("parsing failed:\n\tinvalid field value"));
     }
 
     [Test]
@@ -322,7 +325,7 @@ public class RestClientTest : MockServerTest
     }
 
     [Test]
-    public void ErrorJsonBodyV3WithDataArray()
+    public void ErrorPartialJsonBodyV3WithDataArray()
     {
         CreateAndConfigureRestClient(new ClientConfig
         {
@@ -330,7 +333,7 @@ public class RestClientTest : MockServerTest
         });
 
         MockServer
-            .Given(Request.Create().WithPath("/api").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
                 .WithHeader("X-Influx-Error", "not used")
@@ -339,7 +342,9 @@ public class RestClientTest : MockServerTest
 
         var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
         {
-            await _client.Request("api", HttpMethod.Post);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("accept_partial", true.ToString().ToLowerInvariant());
+            await _client.Request("api/v3/write_lp", HttpMethod.Post, null, queryParams);
         });
 
         Assert.Multiple(() =>
@@ -355,7 +360,7 @@ public class RestClientTest : MockServerTest
     }
 
     [Test]
-    public void ErrorJsonBodyV3WithDataArrayUntypedFallback()
+    public void ErrorPartialJsonBodyV3WithDataArrayUntypedFallback()
     {
         CreateAndConfigureRestClient(new ClientConfig
         {
@@ -363,15 +368,17 @@ public class RestClientTest : MockServerTest
         });
 
         MockServer
-            .Given(Request.Create().WithPath("/api").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
                 .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[\"bad line\",true,3]}")
                 .WithStatusCode(400));
 
-        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
+        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
         {
-            await _client.Request("api", HttpMethod.Post);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("accept_partial", true.ToString().ToLowerInvariant());
+            await _client.Request("api/v3/write_lp", HttpMethod.Post, null, queryParams);
         });
 
         Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\t\"bad line\"\n\ttrue\n\t3"));
@@ -392,7 +399,7 @@ public class RestClientTest : MockServerTest
                 .WithBody("{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":2,\"original_line\":\"home,room=Sunroom temp=hi 1735549200\"}}")
                 .WithStatusCode(400));
 
-        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
         {
             await _client.Request("api", HttpMethod.Post);
         });
@@ -400,16 +407,12 @@ public class RestClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(ae, Is.Not.Null);
-            Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
-            Assert.That(ae.LineErrors[0].LineNumber, Is.EqualTo(2));
-            Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid field value"));
-            Assert.That(ae.LineErrors[0].OriginalLine, Is.EqualTo("home,room=Sunroom temp=hi 1735549200"));
             Assert.That(ae.Message, Is.EqualTo("parsing failed for write_lp endpoint:\n\tline 2: invalid field value (home,room=Sunroom temp=hi 1735549200)"));
         });
     }
 
     [Test]
-    public void ErrorJsonBodyV3PartialWriteWithDataObjectErrorMessageOnly()
+    public void ErrorJsonBodyV3ParsingFailedWriteLpWithInvalidLineNumberDataObject()
     {
         CreateAndConfigureRestClient(new ClientConfig
         {
@@ -420,10 +423,11 @@ public class RestClientTest : MockServerTest
             .Given(Request.Create().WithPath("/api").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
-                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"invalid field value\"}}")
+                .WithBody(
+                    "{\"error\":\"parsing failed for write_lp endpoint\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":\"aa\",\"original_line\":\"home,room=Sunroom temp=hi 1735549200\"}}")
                 .WithStatusCode(400));
 
-        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+        var ae = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
         {
             await _client.Request("api", HttpMethod.Post);
         });
@@ -431,12 +435,41 @@ public class RestClientTest : MockServerTest
         Assert.Multiple(() =>
         {
             Assert.That(ae, Is.Not.Null);
+            Assert.That(ae.Message, Is.EqualTo("parsing failed for write_lp endpoint:\n\tinvalid field value"));
+        });
+    }
+    
+    [Test]
+    public void ErrorJsonBodyV3PartialWriteWithDataObjectErrorMessageOnly()
+    {
+        CreateAndConfigureRestClient(new ClientConfig
+        {
+            Host = MockServerUrl,
+        });
+
+        MockServer
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
+            .RespondWith(Response.Create()
+                .WithHeader("Content-Type", "application/json")
+                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"invalid field value\"}]}")
+                .WithStatusCode(400));
+
+        var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+        {
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("accept_partial", true.ToString().ToLowerInvariant());
+            await _client.Request("api/v3/write_lp", HttpMethod.Post, null, queryParams);
+        });
+
+        using (Assert.EnterMultipleScope())
+        {
+            Assert.That(ae, Is.Not.Null);
             Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
             Assert.That(ae.LineErrors[0].LineNumber, Is.Null);
             Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid field value"));
             Assert.That(ae.LineErrors[0].OriginalLine, Is.Null);
             Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\tinvalid field value"));
-        });
+        }
     }
 
     [Test]
@@ -448,18 +481,20 @@ public class RestClientTest : MockServerTest
         });
 
         MockServer
-            .Given(Request.Create().WithPath("/api").UsingPost())
+            .Given(Request.Create().WithPath("/api/v3/write_lp").UsingPost())
             .RespondWith(Response.Create()
                 .WithHeader("Content-Type", "application/json")
-                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"invalid field value\",\"line_number\":2}}")
+                .WithBody("{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"invalid field value\",\"line_number\":2}]}")
                 .WithStatusCode(400));
 
         var ae = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
         {
-            await _client.Request("api", HttpMethod.Post);
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("accept_partial", true.ToString().ToLowerInvariant());
+            await _client.Request("api/v3/write_lp", HttpMethod.Post, null, queryParams);
         });
 
-        Assert.Multiple(() =>
+        using (Assert.EnterMultipleScope())
         {
             Assert.That(ae, Is.Not.Null);
             Assert.That(ae.LineErrors, Has.Count.EqualTo(1));
@@ -467,7 +502,7 @@ public class RestClientTest : MockServerTest
             Assert.That(ae.LineErrors[0].ErrorMessage, Is.EqualTo("invalid field value"));
             Assert.That(ae.LineErrors[0].OriginalLine, Is.Null);
             Assert.That(ae.Message, Is.EqualTo("partial write of line protocol occurred:\n\tline 2: invalid field value"));
-        });
+        }
     }
 
     [Test]
@@ -506,6 +541,175 @@ public class RestClientTest : MockServerTest
         });
 
         Assert.That(_client, Is.Not.Null);
+    }
+
+    private const string RejectedLine = "home,room=Sunroom temp=\"hi\" 1735545610";
+    private const string RejectedLineJson = "home,room=Sunroom temp=\\\"hi\\\" 1735545610";
+
+    private const string LineError = "invalid column type for column 'temp', expected " +
+                                     "iox::column_type::field::float, got iox::column_type::field::string";
+
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}]}",
+        false, true, "partial write of line protocol occurred:\n\tline 2: " + LineError + " (" + RejectedLine + ")",
+        true,
+        2, LineError, RejectedLine,
+        TestName = "V3 accept partial with renamed error and non-empty array")]
+    [TestCase(HttpStatusCode.BadRequest, null,
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}]}",
+        false, true, "partial write of line protocol occurred:\n\tline 2: " + LineError + " (" + RejectedLine + ")",
+        true,
+        2, LineError, RejectedLine,
+        TestName = "V3 accept partial without content type")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"line_number\":\"invalid\",\"original_line\":\"" +
+        RejectedLineJson + "\"}]}",
+        false, true,
+        "partial write of line protocol occurred:\n\t{\"line_number\":\"invalid\",\"original_line\":\"" +
+        RejectedLineJson + "\"}", true,
+        TestName = "V3 accept partial with malformed non-empty array")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[1,{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}]}",
+        false, true,
+        "partial write of line protocol occurred:\n\t1\n\t{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}", true,
+        2, LineError, RejectedLine,
+        TestName = "V3 accept partial with mixed primitive and typed entries")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[\"" + RejectedLineJson + "\"]}",
+        false, true, "partial write of line protocol occurred:\n\t\"" + RejectedLineJson + "\"", true,
+        TestName = "V3 accept partial with string entries")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError + "\"}]}",
+        false, true, "partial write of line protocol occurred:\n\t" + LineError, true,
+        null, LineError, null,
+        TestName = "V3 accept partial with error message only")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2}]}",
+        false, true, "partial write of line protocol occurred:\n\tline 2: " + LineError, true,
+        2, LineError, null,
+        TestName = "V3 accept partial with line number but no original line")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"line_number\":2,\"original_line\":\"" +
+        RejectedLineJson + "\"}]}",
+        false, true,
+        "partial write of line protocol occurred:\n\t{\"line_number\":2,\"original_line\":\"" + RejectedLineJson +
+        "\"}", true,
+        TestName = "V3 accept partial with entry missing error message")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"write failed\",\"data\":[]}",
+        false, true, "write failed", false,
+        TestName = "V3 accept partial with empty array")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}}",
+        false, true, "partial write of line protocol occurred:\n\tline 2: " + LineError + " (" + RejectedLine + ")",
+        false,
+        TestName = "V3 accept partial with object details remains generic")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"line protocol parsing error\",\"data\":{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}}",
+        false, false, "line protocol parsing error:\n\tline 2: " + LineError + " (" + RejectedLine + ")", false,
+        TestName = "V3 reject partial with object details")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}]}",
+        true, true, "partial write of line protocol occurred", false,
+        TestName = "V2 never returns partial write error")]
+    [TestCase(HttpStatusCode.InternalServerError, "application/json",
+        "{\"error\":\"partial write of line protocol occurred\",\"data\":[{\"error_message\":\"" + LineError +
+        "\",\"line_number\":2,\"original_line\":\"" + RejectedLineJson + "\"}]}",
+        false, true, "partial write of line protocol occurred", false,
+        TestName = "V3 non-400 never returns partial write error")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"write failed\",\"data\":\"invalid\"}",
+        false, true, "write failed", false,
+        TestName = "V3 scalar data remains generic")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"write failed\",\"data\":{}}",
+        false, true, "write failed", false,
+        TestName = "V3 empty object data remains generic")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"write failed\",\"data\":null}",
+        false, true, "write failed", false,
+        TestName = "V3 null data remains generic")]
+    [TestCase(HttpStatusCode.BadRequest, "application/json",
+        "{\"error\":\"write failed\"",
+        false, true, "{\"error\":\"write failed\"", false,
+        TestName = "V3 malformed JSON preserves raw response")]
+    public Task TestWriteErrorClassification(
+        HttpStatusCode statusCode,
+        string? contentType,
+        string responseBody,
+        bool useV2Api,
+        bool acceptPartial,
+        string expectedMsg,
+        bool expectPartial,
+        int? expectedLineNumber = null,
+        string? expectedErrorMessage = null,
+        string? expectedOriginalLine = null)
+    {
+        try
+        {
+            CreateAndConfigureRestClient(new ClientConfig
+            {
+                Host = MockServerUrl,
+            });
+
+            var path = useV2Api ? "api/v2/write_lp" : "api/v3/write_lp";
+            var response = Response.Create()
+                .WithStatusCode(statusCode)
+                .WithBody(responseBody);
+            if (contentType != null)
+            {
+                response.WithHeader("Content-Type", contentType);
+            }
+
+            MockServer
+                .Given(Request.Create().WithPath("/" + path).UsingPost())
+                .RespondWith(response);
+
+            var queryParams = new Dictionary<string, string>();
+            queryParams.Add("accept_partial", acceptPartial.ToString().ToLowerInvariant());
+
+            if (expectPartial)
+            {
+                var ex = Assert.ThrowsAsync<InfluxDBPartialWriteException>(async () =>
+                {
+                    await _client.Request(path, HttpMethod.Post, null, queryParams);
+                });
+                Assert.That(ex, Is.Not.Null);
+                Assert.That(ex!.Message, Is.EqualTo(expectedMsg));
+                if (expectedErrorMessage != null || expectedLineNumber != null || expectedOriginalLine != null)
+                {
+                    using (Assert.EnterMultipleScope())
+                    {
+                        Assert.That(ex.LineErrors[0].LineNumber, Is.EqualTo(expectedLineNumber));
+                        Assert.That(ex.LineErrors[0].ErrorMessage, Is.EqualTo(expectedErrorMessage));
+                        Assert.That(ex.LineErrors[0].OriginalLine, Is.EqualTo(expectedOriginalLine));
+                    }
+                }
+            }
+            else
+            {
+                var ex = Assert.ThrowsAsync<InfluxDBApiException>(async () =>
+                {
+                    await _client.Request(path, HttpMethod.Post, null, queryParams);
+                });
+                Assert.That(ex, Is.InstanceOf<InfluxDBApiException>());
+                Assert.That(ex!.Message, Is.EqualTo(expectedMsg));
+            }
+
+            return Task.CompletedTask;
+        }
+        catch (Exception exception)
+        {
+            return Task.FromException(exception);
+        }
     }
 
     private void CreateAndConfigureRestClient(ClientConfig config)

--- a/Client/Internal/RestClient.cs
+++ b/Client/Internal/RestClient.cs
@@ -83,7 +83,9 @@ internal class RestClient
         {
             var body = await result.Content.ReadAsStringAsync().ConfigureAwait(false);
             var contentType = result.Content?.Headers?.ContentType?.ToString();
-            var parsed = ParseErrorMessage(body, contentType);
+            var acceptPartial = queryParams?.TryGetValue("accept_partial", out var value) != true ||
+                                !string.Equals(value, "false", StringComparison.OrdinalIgnoreCase);
+            var parsed = ParseErrorMessage(body, contentType, (int)result.StatusCode, path, acceptPartial);
             var message = parsed.Message;
             var partialLineErrors = parsed.PartialLineErrors;
 
@@ -108,7 +110,7 @@ internal class RestClient
                 message = result.ReasonPhrase;
             }
 
-            if (partialLineErrors?.Count > 0)
+            if (partialLineErrors != null)
             {
                 throw new InfluxDBPartialWriteException(message ?? "Cannot write data to InfluxDB.", result, partialLineErrors);
             }
@@ -119,7 +121,9 @@ internal class RestClient
         return result;
     }
 
-    private static ParsedErrorMessage ParseErrorMessage(string body, string? contentType)
+    private static ParsedErrorMessage ParseErrorMessage(
+        string body, string? contentType, int statusCode, string path, bool acceptPartial
+    )
     {
         if (string.IsNullOrWhiteSpace(body))
         {
@@ -145,16 +149,18 @@ internal class RestClient
             var topLevelError = GetStringProperty(root, "error");
             var data = GetProperty(root, "data");
 
-            var legacyDataMessage = GetLegacyDataErrorMessage(data);
-            var message = cloudMessage ??
-                          CombineMessages(topLevelError, legacyDataMessage) ??
-                          topLevelError ??
-                          legacyDataMessage;
-            var partial = ParsePartialWrite(topLevelError, data);
-            if (partial is not null)
+            if (IsPartialWriteError(statusCode, path, acceptPartial, root))
             {
+                var partial = ParsePartialWrite(topLevelError, data);
                 return partial;
             }
+
+            var legacyDataMessage = GetLegacyDataErrorMessage(data);
+            var message = cloudMessage ??
+                          topLevelError ??
+                          legacyDataMessage;
+
+            message = FormatObjectDataError(data, message);
 
             return new ParsedErrorMessage(message, null);
         }
@@ -165,50 +171,57 @@ internal class RestClient
         }
     }
 
-    private static ParsedErrorMessage? ParsePartialWrite(string? topLevelError, JsonElement? data)
+    private static string? FormatObjectDataError(JsonElement? data, string? error)
     {
-        if (string.IsNullOrEmpty(topLevelError) || !IsPartialWriteError(topLevelError))
+        if (data is not { ValueKind: JsonValueKind.Object } dataObject)
         {
-            return null;
-        }
-        if (data is null)
-        {
-            return null;
+            return error;
         }
 
-        if (data.Value.ValueKind == JsonValueKind.Array)
+        var errorMessage = GetStringProperty(dataObject, "error_message");
+        if (string.IsNullOrEmpty(errorMessage))
         {
-            if (TryParseTypedLineErrors(data.Value, out var lineErrors))
-            {
-                return new ParsedErrorMessage(BuildPartialWriteMessage(topLevelError, lineErrors), lineErrors);
-            }
-
-            var details = data.Value.EnumerateArray()
-                .Where(item => item.ValueKind != JsonValueKind.Null)
-                .Select(ToDetailString)
-                .Where(item => !string.IsNullOrEmpty(item))
-                .ToList();
-
-            if (details.Count > 0)
-            {
-                return new ParsedErrorMessage($"{topLevelError}:\n\t{string.Join("\n\t", details)}", null);
-            }
-
-            return null;
+            return error;
         }
 
-        if (data.Value.ValueKind == JsonValueKind.Object)
+        if (string.IsNullOrEmpty(error) || string.Equals(error, errorMessage, StringComparison.Ordinal))
         {
-            if (TryParseTypedLineError(data.Value, out var lineError))
-            {
-                var lineErrors = new List<InfluxDBPartialWriteException.LineError> { lineError };
-                return new ParsedErrorMessage(BuildPartialWriteMessage(topLevelError, lineErrors), lineErrors);
-            }
-
-            return null;
+            return errorMessage;
         }
 
-        return null;
+        var lineNumber = GetProperty(dataObject, "line_number");
+        var hasValidLine = lineNumber is not null && int.TryParse(lineNumber.ToString(), out _);
+
+        if (!hasValidLine)
+        {
+            return $"{error}:\n\t{errorMessage}";
+        }
+
+        var originalLine = GetStringProperty(dataObject, "original_line");
+        var lineDetail = string.IsNullOrEmpty(originalLine)
+            ? $"line {lineNumber}: {errorMessage}"
+            : $"line {lineNumber}: {errorMessage} ({originalLine})";
+
+        return $"{error}:\n\t{lineDetail}";
+    }
+
+    private static ParsedErrorMessage ParsePartialWrite(string? topLevelError, JsonElement? data)
+    {
+        if (TryParseTypedLineErrors(data.Value, out var lineErrors))
+        {
+            return new ParsedErrorMessage(BuildPartialWriteMessage(topLevelError, lineErrors), lineErrors);
+        }
+
+        var details = data.Value.EnumerateArray()
+            .Where(item => item.ValueKind != JsonValueKind.Null)
+            .Select(ToDetailString)
+            .Where(item => !string.IsNullOrEmpty(item))
+            .ToList();
+
+        return new ParsedErrorMessage(
+            $"{topLevelError}:\n\t{string.Join("\n\t", details)}",
+            lineErrors
+        );
     }
 
     private static string BuildPartialWriteMessage(
@@ -245,32 +258,25 @@ internal class RestClient
         return message.ToString();
     }
 
-    private static bool IsPartialWriteError(string topLevelError)
+    private static bool IsPartialWriteError(int statusCode, string path, bool acceptPartial, JsonElement root)
     {
-        return topLevelError.IndexOf("partial write of line protocol occurred", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               topLevelError.IndexOf("parsing failed for write_lp endpoint", StringComparison.OrdinalIgnoreCase) >= 0 ||
-               topLevelError.IndexOf("line protocol parsing error", StringComparison.OrdinalIgnoreCase) >= 0;
+        return statusCode == 400 && acceptPartial && path.Equals("api/v3/write_lp", StringComparison.Ordinal) &&
+               IsPartialWriteErrorShape(root);
     }
 
-    private static string? CombineMessages(string? topLevelError, string? dataMessage)
+    private static bool IsPartialWriteErrorShape(JsonElement root)
     {
-        if (string.IsNullOrEmpty(topLevelError) || string.IsNullOrEmpty(dataMessage))
-        {
-            return null;
-        }
-
-        if (string.Equals(topLevelError, dataMessage, StringComparison.Ordinal))
-        {
-            return topLevelError;
-        }
-
-        return $"{topLevelError}: {dataMessage}";
+        return (root.ValueKind == JsonValueKind.Object &&
+                GetStringProperty(root, "error") != null &&
+                GetProperty(root, "data")?.ValueKind == JsonValueKind.Array &&
+                GetProperty(root, "data")?.EnumerateArray().Any() == true);
     }
 
     private static bool TryParseTypedLineErrors(
         JsonElement data,
         out List<InfluxDBPartialWriteException.LineError> lineErrors)
     {
+        var isTyped = true;
         lineErrors = new List<InfluxDBPartialWriteException.LineError>();
         if (data.ValueKind != JsonValueKind.Array)
         {
@@ -281,14 +287,13 @@ internal class RestClient
         {
             if (!TryParseTypedLineError(item, out var lineError))
             {
-                lineErrors.Clear();
-                return false;
+                isTyped = false;
+                continue;
             }
-
             lineErrors.Add(lineError);
         }
 
-        return lineErrors.Count > 0;
+        return isTyped;
     }
 
     private static bool TryParseTypedLineError(JsonElement item, out InfluxDBPartialWriteException.LineError lineError)


### PR DESCRIPTION
Closes #

## Proposed Changes

- How the errors are handled and test cases adjustment in this PR are heavily influenced by this [PR](https://github.com/InfluxCommunity/influxdb3-go/pull/266).

## Changes

- Tests were modified to accommodate with new definitions of partial write errors, which are:
          - Error response status code is `400`.
          - Error response format `{"error":"...","data":[{"error_message":"...","line_number":2,"original_line": "..."}]}` is returned with `data` must be an array.
          - `accept_partial` is set to `true`.
          - Write endpoint must be `api/v3/write_lp`.

## Checklist

<!-- Checkboxes below this note can be erased if not applicable to your Pull Request. -->

- [x] CHANGELOG.md updated
- [x] Rebased/mergeable
- [x] A test has been added if appropriate
- [x] Tests pass
- [x] Commit messages are [conventional](https://www.conventionalcommits.org/en/v1.0.0/)
- [x] Sign [CLA](https://www.influxdata.com/legal/cla/) (if not already signed)
